### PR TITLE
docs: add workspace analysis reports

### DIFF
--- a/specs/workspace-analysis-report.md
+++ b/specs/workspace-analysis-report.md
@@ -1,0 +1,48 @@
+# Workspace Analysis Report
+
+Date: 2026-03-08
+Repository: `nikomatt69/nikcli`
+Branch analyzed: `dev`
+Latest commit at analysis time: `dd6eecc` - `feat: introduce chatbot functionality and enhance Docker setup`
+
+## Workspace status
+
+- The working tree was clean at the time of analysis.
+- `dev` was aligned with `origin/dev`, so there were no unmerged local changes available for a PR into `dev`.
+- A dedicated docs branch was created after the analysis so this report could be proposed back into `dev`.
+
+## Recent change clusters
+
+### Chatbot platform support
+
+- Added a new chatbot module with handlers and entrypoints in `packages/nikcli/src/chatbot/`.
+- Introduced chatbot-focused CLI flows in `packages/nikcli/src/cli/cmd/chatbot.ts`.
+- Added a server route in `packages/nikcli/src/server/routes/chatbot.ts`.
+- Expanded connector coverage for Discord, Slack, Teams, Google Chat, and Linear.
+
+### Workspace and session infrastructure
+
+- Added workspace-serving and workspace route support in `packages/nikcli/src/cli/cmd/workspace-serve.ts` and `packages/nikcli/src/server/routes/workspace.ts`.
+- Introduced a new workspace subsystem in `packages/nikcli/src/workspace/` for adaptors, config, SSE, routing, and server wiring.
+- Updated remote session handling in `packages/nikcli/src/cli/remote/remote-service.ts` and related types.
+- Refreshed TUI session and dialog flows to surface the new capabilities.
+
+### Deployment and operations
+
+- Added `Dockerfile.serve`, `docker-compose.serve.yml`, and `.dockerignore`.
+- Added a GitHub workflow at `.github/workflows/nikcli-agent.yml`.
+- Updated root and package-level `package.json` files to support the new integrations.
+- Reworked configuration layout by removing the old root `config.json` and adding `packages/nikcli/config.json`.
+
+### SDK, docs, and integrations
+
+- Regenerated JavaScript SDK outputs in `packages/sdk/js/src/v2/gen/`.
+- Updated `packages/remote/src/server.ts` to match the new server surface.
+- Updated Slack deployment/runtime files in `packages/slack/`.
+- Refreshed docs in `packages/web/src/pages/docs/` and `README.md`.
+
+## Overall assessment
+
+- The codebase is currently in a stable git state, but the latest shipped change is broad and touches CLI, server, SDK, Slack, docs, and deployment paths.
+- The biggest concentration of change is around chatbot orchestration and multi-workspace/session support.
+- Because the recent feature commit already lives on `origin/dev`, any new PR into `dev` needs to carry fresh changes rather than repackaging existing work.

--- a/specs/workspace-risk-report.md
+++ b/specs/workspace-risk-report.md
@@ -1,0 +1,38 @@
+# Workspace Risk Report
+
+Date: 2026-03-08
+Analysis basis: git status, branch inspection, recent commit history, and latest commit diff statistics.
+
+## Primary risk areas
+
+### Cross-surface feature scope
+
+- The latest feature set spans CLI commands, TUI state, HTTP routes, remote services, SDK generation, and Slack runtime code.
+- Broad changes like this increase the chance of interface drift between packages when follow-up work lands.
+
+### Deployment path changes
+
+- New Docker and compose assets add operational flexibility, but they also create another runtime path that should be smoke-tested after infrastructure or env changes.
+- The new GitHub workflow should be watched for environment assumptions or missing secrets.
+
+### Generated API artifacts
+
+- Regenerated SDK files need to stay in sync with `packages/nikcli/src/server/server.ts` and related route definitions.
+- Any future API edits should continue to regenerate `packages/sdk/js` before merge.
+
+### Slack and chatbot integrations
+
+- Multi-platform chatbot support expands external dependency and credential surface area.
+- Slack runtime changes and new chatbot handlers deserve end-to-end validation with real connector configuration before wider rollout.
+
+## Recommended follow-up checks
+
+- Run targeted smoke tests for chatbot flows and workspace-serving flows.
+- Validate Docker serve startup with the new compose stack.
+- Confirm SDK consumers still build cleanly after the generated client/type updates.
+- Review docs paths for any stale configuration references after the `config.json` layout change.
+
+## Report purpose
+
+- This document is intended to capture the current repo state in versioned markdown so reviewers can quickly understand where the workspace is stable and where the newest change surface is concentrated.
+- The companion report in `specs/workspace-analysis-report.md` records the structural summary; this file focuses on risk and verification priorities.


### PR DESCRIPTION
## Summary
- add `specs/workspace-analysis-report.md` and `specs/workspace-risk-report.md` with a versioned snapshot of the current workspace state
- document the main change clusters already living on `dev`, including chatbot, workspace/session, deployment, SDK, and integration work
- capture the main risk areas and recommended follow-up checks so reviewers have a lightweight assessment in-repo

## How did you verify your code works?
- reviewed git status, branch alignment, recent commit history, and latest commit diff statistics to produce the reports
- verified this branch diff only adds the two markdown report files
- did not run runtime tests because this PR only adds documentation