### PR TITLE
fix: tui event validation and monitor stream cleanup

### DIFF
--- a/packages/nikcli/src/monitor/manager.ts
+++ b/packages/nikcli/src/monitor/manager.ts
@@ -134,7 +134,7 @@ export namespace Monitor {
             await Shell.killTree(runtime.process, { exited: () => runtime.exited })
           } catch {}
           try {
-            runtime.logStream.end()
+            if (!runtime.logStream.writableEnded) runtime.logStream.end()
           } catch {}
         }),
       )

--- a/packages/nikcli/src/server/routes/tui.ts
+++ b/packages/nikcli/src/server/routes/tui.ts
@@ -345,7 +345,9 @@ export const TuiRoutes = lazy(() =>
       ),
       async (c) => {
         const evt = c.req.valid("json")
-        await Bus.publish(Object.values(TuiEvent).find((def) => def.type === evt.type)!, evt.properties)
+        const def = Object.values(TuiEvent).find((def) => def.type === evt.type)
+        if (!def) return c.json({ error: "Unknown event type" }, 400)
+        await Bus.publish(def, evt.properties)
         return c.json(true)
       },
     )


### PR DESCRIPTION
## Summary
- **server/routes/tui.ts**: Add null check for unknown event types before Bus.publish (prevents crash on malformed input)
- **monitor/manager.ts**: Guard logStream.end() with writableEnded check to prevent double-end errors during shutdown race

## Changes
### tui.ts (lines 347-350)
Before: `await Bus.publish(Object.values(TuiEvent).find((def) => def.type === evt.type)!, evt.properties)`
After: Proper validation with error response for unknown event types

### monitor/manager.ts (line 137)
Before: `runtime.logStream.end()`
After: `if (!runtime.logStream.writableEnded) runtime.logStream.end()`