### PR TITLE
feat(file): integrate fff-bun as primary file/dir search backend

### DIFF
--- a/packages/nikcli/package.json
+++ b/packages/nikcli/package.json
@@ -84,6 +84,7 @@
     "@chat-adapter/state-redis": "4.14.0",
     "@chat-adapter/teams": "4.14.0",
     "@clack/prompts": "1.0.0-alpha.1",
+    "@ff-labs/fff-bun": "0.6.4",
     "@gitlab/gitlab-ai-provider": "3.1.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",

--- a/packages/nikcli/src/file/fff.ts
+++ b/packages/nikcli/src/file/fff.ts
@@ -1,0 +1,117 @@
+import path from "path"
+import fs from "fs/promises"
+import { FileFinder, type GrepOptions, type GrepResult, type SearchOptions } from "@ff-labs/fff-bun"
+import { Instance } from "../project/instance"
+import { Global } from "../global"
+import { Log } from "../util/log"
+
+export namespace FFF {
+  const log = Log.create({ service: "fff" })
+
+  type Ready = {
+    available: true
+    finder: FileFinder
+  }
+
+  type Unavailable = {
+    available: false
+    error: string
+  }
+
+  type Handle = Ready | Unavailable
+
+  function projectKey(dir: string) {
+    return Buffer.from(dir).toString("hex").slice(0, 32) + "-" + path.basename(dir)
+  }
+
+  const state = Instance.state(
+    async (): Promise<Handle> => {
+      const dir = Instance.directory
+      try {
+        const dbDir = path.join(Global.Path.cache, "fff", projectKey(dir))
+        await fs.mkdir(dbDir, { recursive: true })
+
+        const created = FileFinder.create({
+          basePath: dir,
+          frecencyDbPath: path.join(dbDir, "frecency.mdb"),
+          historyDbPath: path.join(dbDir, "history.mdb"),
+          aiMode: true,
+        })
+
+        if (!created.ok) {
+          log.warn("FileFinder.create failed", { error: created.error })
+          return { available: false, error: created.error }
+        }
+
+        log.info("initialized", { dir, dbDir })
+        return { available: true, finder: created.value }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        log.warn("init threw", { error: message })
+        return { available: false, error: message }
+      }
+    },
+    async (handle) => {
+      if (handle.available) {
+        try {
+          handle.finder.destroy()
+        } catch (error) {
+          log.warn("destroy failed", { error })
+        }
+      }
+    },
+  )
+
+  export async function available(): Promise<boolean> {
+    return (await state()).available
+  }
+
+  async function ready(): Promise<Ready | undefined> {
+    const handle = await state()
+    return handle.available ? handle : undefined
+  }
+
+  export async function searchFiles(query: string, opts?: SearchOptions): Promise<string[] | undefined> {
+    const r = await ready()
+    if (!r) return undefined
+    const result = r.finder.fileSearch(query, opts)
+    if (!result.ok) {
+      log.warn("fileSearch failed", { query, error: result.error })
+      return undefined
+    }
+    return result.value.items.map((item) => item.relativePath)
+  }
+
+  export async function searchDirs(query: string, opts?: SearchOptions): Promise<string[] | undefined> {
+    const r = await ready()
+    if (!r) return undefined
+    const result = r.finder.directorySearch(query, opts)
+    if (!result.ok) {
+      log.warn("directorySearch failed", { query, error: result.error })
+      return undefined
+    }
+    return result.value.items.map((item) => item.relativePath)
+  }
+
+  export async function searchMixed(query: string, opts?: SearchOptions): Promise<string[] | undefined> {
+    const r = await ready()
+    if (!r) return undefined
+    const result = r.finder.mixedSearch(query, opts)
+    if (!result.ok) {
+      log.warn("mixedSearch failed", { query, error: result.error })
+      return undefined
+    }
+    return result.value.items.map((entry) => entry.item.relativePath)
+  }
+
+  export async function grep(query: string, opts?: GrepOptions): Promise<GrepResult | undefined> {
+    const r = await ready()
+    if (!r) return undefined
+    const result = r.finder.grep(query, opts)
+    if (!result.ok) {
+      log.warn("grep failed", { query, error: result.error })
+      return undefined
+    }
+    return result.value
+  }
+}

--- a/packages/nikcli/src/file/fff.ts
+++ b/packages/nikcli/src/file/fff.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs/promises"
+import crypto from "crypto"
 import { FileFinder, type GrepOptions, type GrepResult, type SearchOptions } from "@ff-labs/fff-bun"
 import { Instance } from "../project/instance"
 import { Global } from "../global"
@@ -21,7 +22,8 @@ export namespace FFF {
   type Handle = Ready | Unavailable
 
   function projectKey(dir: string) {
-    return Buffer.from(dir).toString("hex").slice(0, 32) + "-" + path.basename(dir)
+    const hash = crypto.createHash("sha256").update(dir).digest("hex").slice(0, 16)
+    return hash + "-" + path.basename(dir)
   }
 
   const state = Instance.state(
@@ -71,6 +73,13 @@ export namespace FFF {
     return handle.available ? handle : undefined
   }
 
+  // During the initial background scan an empty result is meaningless — it just
+  // means "not indexed yet." Treat empty-while-scanning as undefined so the
+  // caller falls back to its own (eagerly populated) data source.
+  function unusableDuringWarmup(finder: FileFinder, items: unknown[]): boolean {
+    return items.length === 0 && finder.isScanning()
+  }
+
   export async function searchFiles(query: string, opts?: SearchOptions): Promise<string[] | undefined> {
     const r = await ready()
     if (!r) return undefined
@@ -79,6 +88,7 @@ export namespace FFF {
       log.warn("fileSearch failed", { query, error: result.error })
       return undefined
     }
+    if (unusableDuringWarmup(r.finder, result.value.items)) return undefined
     return result.value.items.map((item) => item.relativePath)
   }
 
@@ -90,6 +100,7 @@ export namespace FFF {
       log.warn("directorySearch failed", { query, error: result.error })
       return undefined
     }
+    if (unusableDuringWarmup(r.finder, result.value.items)) return undefined
     return result.value.items.map((item) => item.relativePath)
   }
 
@@ -101,6 +112,7 @@ export namespace FFF {
       log.warn("mixedSearch failed", { query, error: result.error })
       return undefined
     }
+    if (unusableDuringWarmup(r.finder, result.value.items)) return undefined
     return result.value.items.map((entry) => entry.item.relativePath)
   }
 

--- a/packages/nikcli/src/file/index.ts
+++ b/packages/nikcli/src/file/index.ts
@@ -422,9 +422,14 @@ export namespace File {
     const fffResult = await (async () => {
       if (kind === "file") return FFF.searchFiles(query, { pageSize: limit })
       if (kind === "directory") {
-        const dirs = await FFF.searchDirs(query, { pageSize: limit })
+        // Over-fetch like the fuzzysort path so sortHiddenLast has headroom
+        // before truncation; matches the original `limit * 20` behavior.
+        const fetchSize = preferHidden ? limit : limit * 20
+        const dirs = await FFF.searchDirs(query, { pageSize: fetchSize })
         if (!dirs) return undefined
-        return query ? dirs : sortHiddenLast(dirs.toSorted()).slice(0, limit)
+        if (preferHidden) return dirs.slice(0, limit)
+        const ordered = query ? sortHiddenLast(dirs) : sortHiddenLast(dirs.toSorted())
+        return ordered.slice(0, limit)
       }
       return FFF.searchMixed(query, { pageSize: limit })
     })().catch((error) => {

--- a/packages/nikcli/src/file/index.ts
+++ b/packages/nikcli/src/file/index.ts
@@ -12,6 +12,7 @@ import { Instance } from "../project/instance"
 import { Ripgrep } from "./ripgrep"
 import fuzzysort from "fuzzysort"
 import { Global } from "../global"
+import { FFF } from "./fff"
 
 export namespace File {
   const log = Log.create({ service: "file" })
@@ -401,8 +402,6 @@ export namespace File {
     const kind = input.type ?? (input.dirs === false ? "file" : "all")
     log.info("search", { query, kind })
 
-    const result = await state().then((x) => x.files())
-
     const hidden = (item: string) => {
       const normalized = item.replaceAll("\\", "/").replace(/\/+$/, "")
       return normalized.split("/").some((p) => p.startsWith(".") && p.length > 1)
@@ -419,6 +418,27 @@ export namespace File {
       }
       return [...visible, ...hiddenItems]
     }
+
+    const fffResult = await (async () => {
+      if (kind === "file") return FFF.searchFiles(query, { pageSize: limit })
+      if (kind === "directory") {
+        const dirs = await FFF.searchDirs(query, { pageSize: limit })
+        if (!dirs) return undefined
+        return query ? dirs : sortHiddenLast(dirs.toSorted()).slice(0, limit)
+      }
+      return FFF.searchMixed(query, { pageSize: limit })
+    })().catch((error) => {
+      log.warn("fff search threw, falling back", { error })
+      return undefined
+    })
+
+    if (fffResult) {
+      log.info("search", { query, kind, results: fffResult.length, backend: "fff" })
+      return fffResult
+    }
+
+    const result = await state().then((x) => x.files())
+
     if (!query) {
       if (kind === "file") return result.files.slice(0, limit)
       return sortHiddenLast(result.dirs.toSorted()).slice(0, limit)
@@ -431,7 +451,7 @@ export namespace File {
     const sorted = fuzzysort.go(query, items, { limit: searchLimit }).map((r) => r.target)
     const output = kind === "directory" ? sortHiddenLast(sorted).slice(0, limit) : sorted
 
-    log.info("search", { query, kind, results: output.length })
+    log.info("search", { query, kind, results: output.length, backend: "fuzzysort" })
     return output
   }
 }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -12,16 +12,16 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
     },
     "./tool": {
-      "import": "./dist/tool.js",
-      "types": "./dist/tool.d.ts"
+      "import": "./src/tool.ts",
+      "types": "./src/tool.ts"
     },
     "./tui": {
-      "import": "./dist/tui.js",
-      "types": "./dist/tui.d.ts"
+      "import": "./src/tui.ts",
+      "types": "./src/tui.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Adds @ff-labs/fff-bun as a Bun-native fuzzy file finder backed by Rust
via bun:ffi. File.search now tries FFF first (frecency-ranked, with a
warm in-memory index and background watcher), falling back to the
existing ripgrep-cache + fuzzysort path when fff is unavailable.

Ripgrep code is left untouched; FileFinder lifecycle is owned per
project via Instance.state with cleanup on dispose.