### PR TITLE
fix(nikcli): solve startup package re-install loop and correct TypeScript typecheck errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -347,6 +347,7 @@
         "@nikcli-ai/util": "workspace:*",
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
+        "@typescript/native-preview": "catalog:",
       },
     },
     "packages/inference-dashboard": {

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@nikcli-ai/util": "workspace:*",
     "@tsconfig/bun": "catalog:",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "@typescript/native-preview": "catalog:"
   }
 }

--- a/packages/nikcli/src/bun/index.ts
+++ b/packages/nikcli/src/bun/index.ts
@@ -70,7 +70,7 @@ export namespace BunProc {
       await Bun.write(pkgjson.name!, JSON.stringify(result, null, 2))
       return result
     })
-    if (parsed.dependencies[pkg] === version) return mod
+    if (parsed.dependencies[pkg] !== undefined && (version === "latest" || parsed.dependencies[pkg] === version)) return mod
 
     const proxied = !!(
       process.env.HTTP_PROXY ||

--- a/packages/nikcli/src/server/httpapi/session.ts
+++ b/packages/nikcli/src/server/httpapi/session.ts
@@ -21,7 +21,8 @@ export namespace SessionHttpApi {
   )
 
   function cleanJSON<T>(obj: T): T {
-    return obj === undefined ? undefined : JSON.parse(JSON.stringify(obj))
+    if (obj === undefined) return undefined as any
+    return JSON.parse(JSON.stringify(obj))
   }
 
   const ListQuery = Schema.Struct({

--- a/packages/nikcli/src/session/prompt.ts
+++ b/packages/nikcli/src/session/prompt.ts
@@ -2446,6 +2446,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     return bytes.toString()
   }
 
+  export function isUserInitiatedStop(error: unknown): boolean {
+    if (error instanceof DOMException && error.name === "AbortError") return true
+    if (MessageV2.AbortedError.isInstance(error)) return true
+    return false
+  }
+
   export const layer = Layer.succeed(
     Service,
     Service.of({


### PR DESCRIPTION
### Issue for this PR

Closes #77
Also fixes #76 (workspace typecheck failing because `packages/inference` was missing the `tsgo` dependency).

### Type of change

- [x] Bug fix

### What does this PR do?

Two things:

1. Fixes a startup loop where nikcli re-installed its dynamically-loaded packages on every launch instead of detecting an already-satisfied install, plus the Windows-specific ESM/TypeScript resolution errors that came with it.
2. Adds the missing `@typescript/native-preview` devDependency to `packages/inference` so its `tsgo` typecheck script can actually run. Without it the workspace typecheck failed with exit 127 (command not found), which is what was breaking CI on this branch.

### How did you verify your code works?

Ran `turbo run typecheck` across the workspace — all 21 packages pass. Verified `packages/inference` typecheck now runs instead of failing with 127, and that nikcli startup no longer re-enters the install loop.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR