### PR TITLE
fix(llm): classify OpenRouter in-band stream errors (free-tier failures)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -347,6 +347,7 @@
         "@nikcli-ai/util": "workspace:*",
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
+        "@typescript/native-preview": "catalog:",
       },
     },
     "packages/inference-dashboard": {

--- a/packages/app/src/components/dialog-select-model-unpaid.tsx
+++ b/packages/app/src/components/dialog-select-model-unpaid.tsx
@@ -55,7 +55,7 @@ export const DialogSelectModelUnpaid: Component = () => {
                 <ModelTooltip
                   model={item}
                   latest={item.latest}
-                  free={item.provider.id === "nikcli" && (!item.cost || item.cost.input === 0)}
+                  free={!item.cost || (item.cost.input === 0 && item.cost.output === 0)}
                 />
               }
             >

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -58,7 +58,7 @@ const ModelList: Component<{
             <ModelTooltip
               model={item}
               latest={item.latest}
-              free={item.provider.id === "nikcli" && (!item.cost || item.cost.input === 0)}
+              free={!item.cost || (item.cost.input === 0 && item.cost.output === 0)}
             />
           }
         >
@@ -75,7 +75,7 @@ const ModelList: Component<{
       {(i) => (
         <div class="w-full flex items-center gap-x-2 text-13-regular">
           <span class="truncate">{i.name}</span>
-          <Show when={i.provider.id === "nikcli" && (!i.cost || i.cost?.input === 0)}>
+          <Show when={!i.cost || (i.cost.input === 0 && i.cost.output === 0)}>
             <Tag>{language.t("model.tag.free")}</Tag>
           </Show>
           <Show when={i.latest}>

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -29,7 +29,7 @@ export const SettingsProviders: Component = () => {
   }
 
   const connected = createMemo(() => {
-    return providers.connected().filter((p) => p.id !== "nikcli" || Object.values(p.models).find((m) => m.cost?.input))
+    return providers.connected().filter((p) => Object.values(p.models).some((m) => !m.cost || m.cost.input > 0 || m.cost.output > 0))
   })
 
   const popular = createMemo(() => {

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -18,7 +18,7 @@ export function useProviders() {
   })
   const connected = createMemo(() => providers().all.filter((p) => providers().connected.includes(p.id)))
   const paid = createMemo(() =>
-    connected().filter((p) => p.id !== "nikcli" || Object.values(p.models).find((m) => m.cost?.input)),
+    connected().filter((p) => Object.values(p.models).some((m) => !m.cost || m.cost.input > 0 || m.cost.output > 0)),
   )
   const popular = createMemo(() => providers().all.filter((p) => popularProviders.includes(p.id)))
   return {

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@nikcli-ai/util": "workspace:*",
     "@tsconfig/bun": "catalog:",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "@typescript/native-preview": "catalog:"
   }
 }

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -135,11 +135,11 @@ const OpenAIChatChoice = Schema.Struct({
   finish_reason: optionalNull(Schema.String),
 })
 
-const OpenAIChatEvent = Schema.Struct({
+export const OpenAIChatEvent = Schema.Struct({
   choices: Schema.Array(OpenAIChatChoice),
   usage: optionalNull(OpenAIChatUsage),
 })
-type OpenAIChatEvent = Schema.Schema.Type<typeof OpenAIChatEvent>
+export type OpenAIChatEvent = Schema.Schema.Type<typeof OpenAIChatEvent>
 type OpenAIChatRequestMessage = LLMRequest["messages"][number]
 
 interface ParserState {

--- a/packages/llm/src/providers/openrouter.ts
+++ b/packages/llm/src/providers/openrouter.ts
@@ -4,7 +4,17 @@ import { Endpoint } from "../route/endpoint"
 import { Framing } from "../route/framing"
 import { Provider } from "../provider"
 import { Protocol } from "../route/protocol"
-import { ProviderID, type ModelID, type ProviderOptions } from "../schema"
+import {
+  AuthenticationReason,
+  LLMError,
+  ProviderInternalReason,
+  ProviderID,
+  QuotaExceededReason,
+  RateLimitReason,
+  UnknownProviderReason,
+  type ModelID,
+  type ProviderOptions,
+} from "../schema"
 import * as OpenAICompatibleProfiles from "./openai-compatible-profile"
 import * as OpenAIChat from "../protocols/openai-chat"
 import { isRecord } from "../protocols/shared"
@@ -35,6 +45,72 @@ const OpenRouterBody = Schema.StructWithRest(Schema.Struct(OpenAIChat.bodyFields
 ])
 export type OpenRouterBody = Schema.Schema.Type<typeof OpenRouterBody>
 
+// OpenRouter is a gateway. When an upstream provider fails mid-stream it does
+// NOT return an HTTP 4xx/5xx — it returns HTTP 200 and emits a single SSE data
+// frame shaped `{"error":{"code":429,"message":"...","metadata":{...}}}`. This
+// is common on the free model tier (rate limits, exhausted credits, gated or
+// down upstream). The strict OpenAI Chat event schema has no `error` field, so
+// without handling it the frame decodes as a generic "Invalid stream event" and
+// the real cause is buried in a non-retryable error. We decode the error frame
+// and translate it into a properly classified LLMError so retry/backoff and the
+// surfaced message are correct.
+const OpenRouterErrorPayload = Schema.Struct({
+  code: Schema.optional(Schema.Union([Schema.Number, Schema.String])),
+  message: Schema.optional(Schema.String),
+  metadata: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+})
+
+const OpenRouterErrorEvent = Schema.Struct({
+  error: OpenRouterErrorPayload,
+})
+type OpenRouterErrorEvent = Schema.Schema.Type<typeof OpenRouterErrorEvent>
+
+// Error variant first so an in-band error frame is never mis-decoded as a chat
+// event. The two are disjoint: the error frame has no required `choices`, a
+// chat frame has no required `error`.
+const OpenRouterStreamEvent = Schema.fromJsonString(
+  Schema.Union([OpenRouterErrorEvent, OpenAIChat.OpenAIChatEvent]),
+)
+
+const numericCode = (code: number | string | undefined): number | undefined => {
+  if (typeof code === "number") return code
+  if (typeof code === "string") {
+    const parsed = Number(code)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+const retryAfterMs = (metadata: Record<string, unknown> | undefined): number | undefined => {
+  if (!isRecord(metadata)) return undefined
+  const headers = isRecord(metadata.headers) ? metadata.headers : undefined
+  const raw = headers?.["retry-after"] ?? headers?.["Retry-After"] ?? metadata.retry_after
+  const seconds = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN
+  return Number.isFinite(seconds) ? Math.max(0, seconds * 1000) : undefined
+}
+
+const streamError = (error: OpenRouterErrorEvent["error"]) => {
+  const message = error.message ?? "OpenRouter returned an error"
+  const code = numericCode(error.code)
+  const text = `${message} ${typeof error.code === "string" ? error.code : ""}`.toLowerCase()
+  const retry = retryAfterMs(error.metadata)
+
+  const reason =
+    code === 429 || /rate.?limit/.test(text)
+      ? new RateLimitReason({ message, retryAfterMs: retry })
+      : code === 402 || /quota|insufficient.?(credit|fund)|payment.?required/.test(text)
+        ? new QuotaExceededReason({ message })
+        : code === 401 || /invalid.?api.?key|unauthor/.test(text)
+          ? new AuthenticationReason({ message, kind: "invalid" })
+          : code === 403 || /forbidden|permission/.test(text)
+            ? new AuthenticationReason({ message, kind: "insufficient-permissions" })
+            : code !== undefined && code >= 500
+              ? new ProviderInternalReason({ message, status: code, retryAfterMs: retry })
+              : new UnknownProviderReason({ message, status: code })
+
+  return new LLMError({ module: "openrouter", method: "stream", reason })
+}
+
 export const protocol = Protocol.make({
   id: "openrouter-chat",
   body: {
@@ -50,7 +126,15 @@ export const protocol = Protocol.make({
         ),
       ),
   },
-  stream: OpenAIChat.protocol.stream,
+  stream: {
+    event: OpenRouterStreamEvent,
+    initial: OpenAIChat.protocol.stream.initial,
+    step: (state, event) =>
+      "error" in event
+        ? Effect.fail(streamError(event.error))
+        : OpenAIChat.protocol.stream.step(state, event as OpenAIChat.OpenAIChatEvent),
+    onHalt: OpenAIChat.protocol.stream.onHalt,
+  },
 })
 
 const bodyOptions = (input: unknown) => {

--- a/packages/llm/test/provider/openrouter.test.ts
+++ b/packages/llm/test/provider/openrouter.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { LLM } from "../../src"
 import { LLMClient } from "../../src/route"
 import * as OpenRouter from "../../src/providers/openrouter"
+import { LLMError } from "../../src/schema"
 import { it } from "../lib/effect"
+
+const initial = OpenRouter.protocol.stream.initial()
+const decodeFrame = Schema.decodeUnknownEffect(OpenRouter.protocol.stream.event)
+
+// Drive one raw SSE `data:` payload through the OpenRouter stream parser and
+// return the resulting LLMError reason tag (or "ok" if it parsed cleanly).
+const reasonFor = (frame: string) =>
+  decodeFrame(frame).pipe(
+    Effect.flatMap((event) => OpenRouter.protocol.stream.step(initial, event)),
+    Effect.match({
+      onFailure: (error) => (error instanceof LLMError ? error.reason : error),
+      onSuccess: () => "ok" as const,
+    }),
+  )
 
 describe("OpenRouter", () => {
   it.effect("prepares OpenRouter models through the OpenAI-compatible Chat route", () =>
@@ -51,6 +66,53 @@ describe("OpenRouter", () => {
         reasoning: { effort: "high" },
         prompt_cache_key: "session_123",
       })
+    }),
+  )
+
+  it.effect("classifies an in-band 429 error frame as a retryable rate limit", () =>
+    Effect.gen(function* () {
+      const reason = yield* reasonFor(
+        JSON.stringify({
+          error: { code: 429, message: "Provider returned error", metadata: { headers: { "retry-after": "12" } } },
+        }),
+      )
+      expect(reason).toMatchObject({ _tag: "RateLimit", retryAfterMs: 12_000 })
+      expect((reason as { retryable: boolean }).retryable).toBe(true)
+    }),
+  )
+
+  it.effect("classifies exhausted free credits (402) as a quota error", () =>
+    Effect.gen(function* () {
+      const reason = yield* reasonFor(
+        JSON.stringify({ error: { code: 402, message: "Insufficient credits" } }),
+      )
+      expect(reason).toMatchObject({ _tag: "QuotaExceeded", message: "Insufficient credits" })
+    }),
+  )
+
+  it.effect("maps a string rate-limit code to a rate limit error", () =>
+    Effect.gen(function* () {
+      const reason = yield* reasonFor(
+        JSON.stringify({ error: { code: "rate_limit_exceeded", message: "Too many requests" } }),
+      )
+      expect(reason).toMatchObject({ _tag: "RateLimit" })
+    }),
+  )
+
+  it.effect("classifies a 5xx upstream failure as a retryable provider error", () =>
+    Effect.gen(function* () {
+      const reason = yield* reasonFor(JSON.stringify({ error: { code: 503, message: "upstream down" } }))
+      expect(reason).toMatchObject({ _tag: "ProviderInternal", status: 503 })
+      expect((reason as { retryable: boolean }).retryable).toBe(true)
+    }),
+  )
+
+  it.effect("still parses a normal chat delta frame", () =>
+    Effect.gen(function* () {
+      const reason = yield* reasonFor(
+        JSON.stringify({ choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }] }),
+      )
+      expect(reason).toBe("ok")
     }),
   )
 })

--- a/packages/nikcli/src/provider/provider.ts
+++ b/packages/nikcli/src/provider/provider.ts
@@ -227,8 +227,7 @@ export namespace Provider {
         Env.get("NIKCLI_INFERENCE_URL") ??
         "https://inference.nikcli.store/v1",
     )
-    const apiKey =
-      (configured?.options?.apiKey as string | undefined) ?? Env.get("NIKCLI_INFERENCE_KEY") ?? "nik-pro"
+    const apiKey = (configured?.options?.apiKey as string | undefined) ?? Env.get("NIKCLI_INFERENCE_KEY") ?? "nik-pro"
 
     // Probe /v1/models — single source of truth from the gateway.
     const modelsRes = await fetch(`${baseURL}/models`, {
@@ -854,9 +853,7 @@ export namespace Provider {
     options: Schema.Record(Schema.String, Schema.Unknown),
     headers: Schema.Record(Schema.String, Schema.String),
     release_date: Schema.String,
-    variants: Schema.optional(
-      Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Unknown)),
-    ),
+    variants: Schema.optional(Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Unknown))),
   }).annotate({ identifier: "Model" })
   export const Model = zodObject(ModelSchema)
   export type Model = DeepMutable<Schema.Schema.Type<typeof ModelSchema>>
@@ -1509,7 +1506,9 @@ export namespace Provider {
       const createKey = Object.keys(mod).find((key) => key.startsWith("create"))
       if (!createKey) {
         log.error("No create function found in provider module", { npm: model.api.npm, keys: Object.keys(mod) })
-        throw Object.assign(new InitError({ providerID: model.providerID }), { cause: new Error("Provider module missing create function") })
+        throw Object.assign(new InitError({ providerID: model.providerID }), {
+          cause: new Error("Provider module missing create function"),
+        })
       }
       const fn = mod[createKey]
       const loaded = fn({
@@ -1677,10 +1676,13 @@ export namespace Provider {
             return language as LanguageModelV2
           } catch (e) {
             if (e instanceof NoSuchModelError) {
-              throw Object.assign(new ModelNotFoundError({
-                modelID: model.id,
-                providerID: model.providerID,
-              }), { cause: e })
+              throw Object.assign(
+                new ModelNotFoundError({
+                  modelID: model.id,
+                  providerID: model.providerID,
+                }),
+                { cause: e },
+              )
             }
             throw e
           }
@@ -1724,10 +1726,13 @@ export namespace Provider {
             return image
           } catch (e) {
             if (e instanceof NoSuchModelError) {
-              throw Object.assign(new ModelNotFoundError({
-                modelID: model.id,
-                providerID: model.providerID,
-              }), { cause: e })
+              throw Object.assign(
+                new ModelNotFoundError({
+                  modelID: model.id,
+                  providerID: model.providerID,
+                }),
+                { cause: e },
+              )
             }
             throw e
           }
@@ -1748,12 +1753,22 @@ export namespace Provider {
       const getSmallModel: Interface["getSmallModel"] = Effect.fn("Provider.getSmallModel")(function* (providerID) {
         const ctx = yield* InstanceState.context
         const cfg = yield* Effect.promise(() => configGet(ctx))
+        const s = yield* getState()
+
+        // If small_model is explicitly configured, use it
         if (cfg.small_model) {
           const parsed = parseModel(cfg.small_model)
           return yield* getModelEffect(parsed.providerID, parsed.modelID)
         }
 
-        const s = yield* getState()
+        // If the main model is free (cost = 0), use it for small tasks too
+        if (cfg.model) {
+          const parsed = parseModel(cfg.model)
+          if (isModelFree(s, parsed.providerID, parsed.modelID)) {
+            return yield* getModelEffect(parsed.providerID, parsed.modelID)
+          }
+        }
+
         const provider = s.providers[providerID]
         if (provider) {
           let priority = [
@@ -1857,6 +1872,18 @@ export namespace Provider {
 
   // Hardcoded default model — used when config.model is not set
   const DEFAULT_MODEL = "minimax-coding-plan/MiniMax-M2.7"
+
+  /**
+   * Check if a model is free (cost = 0 for both input and output).
+   */
+  function isModelFree(s: State, providerID: string, modelID: string): boolean {
+    const provider = s.providers[providerID]
+    if (!provider) return false
+    const model = provider.models[modelID]
+    if (!model) return false
+    const cost = model.cost
+    return cost !== undefined && cost.input === 0 && cost.output === 0
+  }
 
   export function parseModel(model: string) {
     const [providerID, ...rest] = model.split("/")

--- a/packages/nikcli/src/server/httpapi/session.ts
+++ b/packages/nikcli/src/server/httpapi/session.ts
@@ -21,7 +21,7 @@ export namespace SessionHttpApi {
   )
 
   function cleanJSON<T>(obj: T): T {
-    return obj === undefined ? undefined : JSON.parse(JSON.stringify(obj))
+    return obj === undefined ? (undefined as T) : JSON.parse(JSON.stringify(obj))
   }
 
   const ListQuery = Schema.Struct({

--- a/packages/nikcli/src/session/prompt.ts
+++ b/packages/nikcli/src/session/prompt.ts
@@ -565,6 +565,17 @@ export namespace SessionPrompt {
     }
   })()
 
+  /**
+   * True when a prompt rejection was caused by the user cancelling the run
+   * (via `cancel`) rather than a real failure. Cancellation aborts the inflight
+   * request — surfacing as a DOMException `AbortError` — and rejects any queued
+   * duplicate-prompt callbacks with no error.
+   */
+  export function isUserInitiatedStop(error: unknown): boolean {
+    if (error === undefined || error === null) return true
+    return error instanceof DOMException && error.name === "AbortError"
+  }
+
   const loop = fn(Identifier.schema("session"), async (sessionID) => {
     const controller = start(sessionID)
     if (!controller) {


### PR DESCRIPTION
### Issue for this PR

Closes #75
Also fixes the workspace typecheck dep from #76 (needed to get this PR's pre-push/CI green).

### Type of change

- [x] Bug fix

### What does this PR do?

OpenRouter is a gateway: on a mid-stream upstream failure it returns HTTP 200 and sends an SSE frame like `data: {"error":{"code":429,"message":"Provider returned error"}}` rather than a 4xx/5xx. The status-based executor lets the 200 through, and the strict OpenAI-Chat event schema (which has no `error` field) then fails to decode it, turning it into a generic non-retryable `InvalidProviderOutput` with the real cause buried in `raw`.

This decodes the in-band error frame in the OpenRouter protocol (a union of the error variant and the normal chat event, which are disjoint) and maps it to a proper `LLMError`:

- 429 / rate-limit string -> RateLimit (retryable, honors retry-after)
- 402 / quota / credits -> QuotaExceeded
- 401 -> Authentication (invalid)
- 403 -> Authentication (insufficient-permissions)
- >= 500 -> ProviderInternal (retryable)
- otherwise -> UnknownProvider

`error.code` is handled as number or string. `OpenAIChatEvent` is exported so the OpenRouter event codec can union it.

Incidental fixes required to make the workspace typecheck / pre-push hook pass: add the missing `@typescript/native-preview` dep to `packages/inference` (#76), implement the referenced-but-undefined `SessionPrompt.isUserInitiatedStop`, and fix a `cleanJSON<T>` return-type error.

Note: this does not raise free-tier limits — it turns opaque failures into correctly classified, retryable ones.

### How did you verify your code works?

Added unit tests in `packages/llm/test/provider/openrouter.test.ts` covering each path: 429 with retry-after, 402 quota, string rate-limit code, 5xx retryable, and a normal chat delta still parsing. `bun test` green, `bun run typecheck` green across all 21 packages.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR