### PR TITLE
fix(app): spawn bun by absolute path in e2e-local to fix Windows e2e

### DIFF
--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -83,7 +83,7 @@ const runnerEnv = {
   PLAYWRIGHT_PORT: String(webPort),
 } satisfies Record<string, string>
 
-const seed = Bun.spawn(["bun", "script/seed-e2e.ts"], {
+const seed = Bun.spawn([process.execPath, "script/seed-e2e.ts"], {
   cwd: nikcliDir,
   env: serverEnv,
   stdout: "inherit",
@@ -116,7 +116,7 @@ const result = await (async () => {
   try {
     await waitForHealth(`http://127.0.0.1:${serverPort}/global/health`)
 
-    const runner = Bun.spawn(["bun", "test:e2e", ...extraArgs], {
+    const runner = Bun.spawn([process.execPath, "test:e2e", ...extraArgs], {
       cwd: appDir,
       env: runnerEnv,
       stdout: "inherit",


### PR DESCRIPTION
### Issue for this PR

Closes #79

### Type of change

- [x] Bug fix

### What does this PR do?

The `test (windows)` job fails on every run, before the e2e script even starts:

```
$ bun script/e2e-local.ts
error: could not create process
Bun failed to remap this bin to its proper location within node_modules.
```

Root cause is a nested `bun` resolving a broken trampoline. The job runs `bun test:e2e:local`, whose package-script value is `bun script/e2e-local.ts`. That nested `bun` token resolves through `node_modules/.bin`, where the Windows install (`bun install --linker hoisted`, the documented workaround for oven-sh/bun#28147) leaves a broken `.exe` trampoline.

Two changes fix it:

1. `ci(test)`: run the script file directly (`bun script/e2e-local.ts`) instead of via the `bun test:e2e:local` package script, so there is no nested package-script `bun` to resolve through `node_modules/.bin`.
2. `fix(app)`: inside `e2e-local.ts`, spawn child bun processes by absolute path (`process.execPath`) instead of the bare string `"bun"`, so the seed and playwright spawns don't hit the trampolines either.

### How did you verify your code works?

The failure only reproduces on the Windows CI runner (fresh hoisted install), not locally. With the first version of this PR (in-script fix only) the Windows job got *further* — it failed after ~6 min at the same nested-bun point rather than immediately — which confirmed the remaining failure was the package-script indirection, addressed by change #1. The real verification is this PR's `test (windows)` job.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
