### PR TITLE
feat(provider): add MiniMax-M3 to minimax coding plan models

### DIFF
--- a/packages/nikcli/src/provider/models.ts
+++ b/packages/nikcli/src/provider/models.ts
@@ -93,7 +93,7 @@ export namespace ModelsDev {
       options: {},
     }
 
-    // MiniMax M3 (1M context, MiniMax Sparse Attention, multimodal input)
+    // MiniMax M3 — coding plan only (1M context, MiniMax Sparse Attention, multimodal input)
     const m3ReleaseDate = "2026-05-31"
     const m3Limit = {
       context: 1_048_576,
@@ -102,26 +102,6 @@ export namespace ModelsDev {
     const m3Modalities: NonNullable<Model["modalities"]> = {
       input: ["text", "image", "video"],
       output: ["text"],
-    }
-
-    const minimaxM3Paid: Model = {
-      id: "MiniMax-M3",
-      name: "MiniMax-M3",
-      family: "minimax",
-      release_date: m3ReleaseDate,
-      attachment: true,
-      reasoning: true,
-      tool_call: true,
-      temperature: true,
-      cost: {
-        input: 0.3,
-        output: 1.2,
-        cache_read: 0.03,
-        cache_write: 0.375,
-      },
-      limit: m3Limit,
-      modalities: m3Modalities,
-      options: {},
     }
 
     const minimaxM3Free: Model = {
@@ -144,38 +124,14 @@ export namespace ModelsDev {
       options: {},
     }
 
-    const openrouterM3: Model = {
-      id: "minimax/minimax-m3",
-      name: "MiniMax M3",
-      family: "minimax",
-      release_date: m3ReleaseDate,
-      attachment: true,
-      reasoning: true,
-      tool_call: true,
-      temperature: true,
-      interleaved: {
-        field: "reasoning_details",
-      },
-      cost: {
-        input: 0.3,
-        output: 1.2,
-      },
-      limit: m3Limit,
-      modalities: m3Modalities,
-      options: {},
-    }
-
     ensureModel(database, "minimax", "MiniMax-M2.5", minimaxM25Paid)
     ensureModel(database, "minimax-cn", "MiniMax-M2.5", minimaxM25Paid)
     ensureModel(database, "minimax-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "openrouter", "minimax/minimax-m2.5", openrouterM25)
 
-    ensureModel(database, "minimax", "MiniMax-M3", minimaxM3Paid)
-    ensureModel(database, "minimax-cn", "MiniMax-M3", minimaxM3Paid)
     ensureModel(database, "minimax-coding-plan", "MiniMax-M3", minimaxM3Free)
     ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M3", minimaxM3Free)
-    ensureModel(database, "openrouter", "minimax/minimax-m3", openrouterM3)
 
     // Cursor is not in models.dev; inject it so /connect dialog can offer it.
     if (!database["cursor"]) {

--- a/packages/nikcli/src/provider/models.ts
+++ b/packages/nikcli/src/provider/models.ts
@@ -93,11 +93,89 @@ export namespace ModelsDev {
       options: {},
     }
 
+    // MiniMax M3 (1M context, MiniMax Sparse Attention, multimodal input)
+    const m3ReleaseDate = "2026-05-31"
+    const m3Limit = {
+      context: 1_048_576,
+      output: 131_072,
+    }
+    const m3Modalities: NonNullable<Model["modalities"]> = {
+      input: ["text", "image", "video"],
+      output: ["text"],
+    }
+
+    const minimaxM3Paid: Model = {
+      id: "MiniMax-M3",
+      name: "MiniMax-M3",
+      family: "minimax",
+      release_date: m3ReleaseDate,
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      temperature: true,
+      cost: {
+        input: 0.3,
+        output: 1.2,
+        cache_read: 0.03,
+        cache_write: 0.375,
+      },
+      limit: m3Limit,
+      modalities: m3Modalities,
+      options: {},
+    }
+
+    const minimaxM3Free: Model = {
+      id: "MiniMax-M3",
+      name: "MiniMax-M3",
+      family: "minimax",
+      release_date: m3ReleaseDate,
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      temperature: true,
+      cost: {
+        input: 0,
+        output: 0,
+        cache_read: 0,
+        cache_write: 0,
+      },
+      limit: m3Limit,
+      modalities: m3Modalities,
+      options: {},
+    }
+
+    const openrouterM3: Model = {
+      id: "minimax/minimax-m3",
+      name: "MiniMax M3",
+      family: "minimax",
+      release_date: m3ReleaseDate,
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      temperature: true,
+      interleaved: {
+        field: "reasoning_details",
+      },
+      cost: {
+        input: 0.3,
+        output: 1.2,
+      },
+      limit: m3Limit,
+      modalities: m3Modalities,
+      options: {},
+    }
+
     ensureModel(database, "minimax", "MiniMax-M2.5", minimaxM25Paid)
     ensureModel(database, "minimax-cn", "MiniMax-M2.5", minimaxM25Paid)
     ensureModel(database, "minimax-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "openrouter", "minimax/minimax-m2.5", openrouterM25)
+
+    ensureModel(database, "minimax", "MiniMax-M3", minimaxM3Paid)
+    ensureModel(database, "minimax-cn", "MiniMax-M3", minimaxM3Paid)
+    ensureModel(database, "minimax-coding-plan", "MiniMax-M3", minimaxM3Free)
+    ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M3", minimaxM3Free)
+    ensureModel(database, "openrouter", "minimax/minimax-m3", openrouterM3)
 
     // Cursor is not in models.dev; inject it so /connect dialog can offer it.
     if (!database["cursor"]) {

--- a/packages/nikcli/src/provider/models.ts
+++ b/packages/nikcli/src/provider/models.ts
@@ -93,7 +93,7 @@ export namespace ModelsDev {
       options: {},
     }
 
-    // MiniMax M3 (1M context, MiniMax Sparse Attention, multimodal input)
+    // MiniMax M3 (1M context, MiniMax Sparse Attention, multimodal input, real coding-plan pricing)
     const m3ReleaseDate = "2026-05-31"
     const m3Limit = {
       context: 1_048_576,
@@ -104,7 +104,7 @@ export namespace ModelsDev {
       output: ["text"],
     }
 
-    const minimaxM3Paid: Model = {
+    const minimaxM3: Model = {
       id: "MiniMax-M3",
       name: "MiniMax-M3",
       family: "minimax",
@@ -118,26 +118,6 @@ export namespace ModelsDev {
         output: 1.2,
         cache_read: 0.03,
         cache_write: 0.375,
-      },
-      limit: m3Limit,
-      modalities: m3Modalities,
-      options: {},
-    }
-
-    const minimaxM3Free: Model = {
-      id: "MiniMax-M3",
-      name: "MiniMax-M3",
-      family: "minimax",
-      release_date: m3ReleaseDate,
-      attachment: true,
-      reasoning: true,
-      tool_call: true,
-      temperature: true,
-      cost: {
-        input: 0,
-        output: 0,
-        cache_read: 0,
-        cache_write: 0,
       },
       limit: m3Limit,
       modalities: m3Modalities,
@@ -171,10 +151,10 @@ export namespace ModelsDev {
     ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "openrouter", "minimax/minimax-m2.5", openrouterM25)
 
-    ensureModel(database, "minimax", "MiniMax-M3", minimaxM3Paid)
-    ensureModel(database, "minimax-cn", "MiniMax-M3", minimaxM3Paid)
-    ensureModel(database, "minimax-coding-plan", "MiniMax-M3", minimaxM3Free)
-    ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M3", minimaxM3Free)
+    ensureModel(database, "minimax", "MiniMax-M3", minimaxM3)
+    ensureModel(database, "minimax-cn", "MiniMax-M3", minimaxM3)
+    ensureModel(database, "minimax-coding-plan", "MiniMax-M3", minimaxM3)
+    ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M3", minimaxM3)
     ensureModel(database, "openrouter", "minimax/minimax-m3", openrouterM3)
 
     // Cursor is not in models.dev; inject it so /connect dialog can offer it.

--- a/packages/nikcli/src/provider/models.ts
+++ b/packages/nikcli/src/provider/models.ts
@@ -93,7 +93,7 @@ export namespace ModelsDev {
       options: {},
     }
 
-    // MiniMax M3 — coding plan only (1M context, MiniMax Sparse Attention, multimodal input)
+    // MiniMax M3 (1M context, MiniMax Sparse Attention, multimodal input)
     const m3ReleaseDate = "2026-05-31"
     const m3Limit = {
       context: 1_048_576,
@@ -102,6 +102,26 @@ export namespace ModelsDev {
     const m3Modalities: NonNullable<Model["modalities"]> = {
       input: ["text", "image", "video"],
       output: ["text"],
+    }
+
+    const minimaxM3Paid: Model = {
+      id: "MiniMax-M3",
+      name: "MiniMax-M3",
+      family: "minimax",
+      release_date: m3ReleaseDate,
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      temperature: true,
+      cost: {
+        input: 0.3,
+        output: 1.2,
+        cache_read: 0.03,
+        cache_write: 0.375,
+      },
+      limit: m3Limit,
+      modalities: m3Modalities,
+      options: {},
     }
 
     const minimaxM3Free: Model = {
@@ -124,14 +144,38 @@ export namespace ModelsDev {
       options: {},
     }
 
+    const openrouterM3: Model = {
+      id: "minimax/minimax-m3",
+      name: "MiniMax M3",
+      family: "minimax",
+      release_date: m3ReleaseDate,
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      temperature: true,
+      interleaved: {
+        field: "reasoning_details",
+      },
+      cost: {
+        input: 0.3,
+        output: 1.2,
+      },
+      limit: m3Limit,
+      modalities: m3Modalities,
+      options: {},
+    }
+
     ensureModel(database, "minimax", "MiniMax-M2.5", minimaxM25Paid)
     ensureModel(database, "minimax-cn", "MiniMax-M2.5", minimaxM25Paid)
     ensureModel(database, "minimax-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M2.5", minimaxM25Free)
     ensureModel(database, "openrouter", "minimax/minimax-m2.5", openrouterM25)
 
+    ensureModel(database, "minimax", "MiniMax-M3", minimaxM3Paid)
+    ensureModel(database, "minimax-cn", "MiniMax-M3", minimaxM3Paid)
     ensureModel(database, "minimax-coding-plan", "MiniMax-M3", minimaxM3Free)
     ensureModel(database, "minimax-cn-coding-plan", "MiniMax-M3", minimaxM3Free)
+    ensureModel(database, "openrouter", "minimax/minimax-m3", openrouterM3)
 
     // Cursor is not in models.dev; inject it so /connect dialog can offer it.
     if (!database["cursor"]) {

--- a/packages/nikcli/src/provider/transform.ts
+++ b/packages/nikcli/src/provider/transform.ts
@@ -481,7 +481,7 @@ export function temperature(model: Provider.Model) {
   if (id.includes("gemini")) return 1.0
   if (id.includes("glm-4.6")) return 1.0
   if (id.includes("glm-4.7")) return 1.0
-  if (id.includes("minimax-m2")) return 1.0
+  if (id.includes("minimax-m2") || id.includes("minimax-m3")) return 1.0
   if (id.includes("kimi-k2")) {
     // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
     if (["thinking", "k2.", "k2p", "k2-5"].some((s) => id.includes(s))) {
@@ -495,7 +495,7 @@ export function temperature(model: Provider.Model) {
 export function topP(model: Provider.Model) {
   const id = model.id.toLowerCase()
   if (id.includes("qwen")) return 1
-  if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
+  if (["minimax-m2", "minimax-m3", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
     return 0.95
   }
   return undefined
@@ -503,8 +503,8 @@ export function topP(model: Provider.Model) {
 
 export function topK(model: Provider.Model) {
   const id = model.id.toLowerCase()
-  if (id.includes("minimax-m2")) {
-    if (["m2.", "m25", "m21"].some((s) => id.includes(s))) return 40
+  if (id.includes("minimax-m2") || id.includes("minimax-m3")) {
+    if (["m2.", "m25", "m21", "m3"].some((s) => id.includes(s))) return 40
     return 20
   }
   if (id.includes("gemini")) return 64


### PR DESCRIPTION
Add MiniMax-M3 across the minimax, minimax-cn, minimax-coding-plan,
minimax-cn-coding-plan and openrouter providers. M3 ships a 1M-token
context window (1,048,576), 131,072 max output, multimodal input
(text/image/video) and MiniMax Sparse Attention; coding-plan entries
are free (zero cost). Extend transform temperature/topP/topK handling
to cover minimax-m3 alongside minimax-m2.