### PR TITLE
fix(nikcli): Effect TS review — runtime entries, error handling, resource safety

### DIFF
--- a/packages/nikcli/src/auth/index.ts
+++ b/packages/nikcli/src/auth/index.ts
@@ -285,8 +285,13 @@ export namespace Auth {
       try {
         const text = await fs.readFile(filepath(), "utf-8")
         data = JSON.parse(text)
-      } catch {
-        // File doesn't exist or is corrupted, leave data empty
+      } catch (error) {
+        // Missing file is the normal first-run case; anything else means the
+        // auth store is unreadable and silently treating it as empty would
+        // make stored credentials vanish without a trace.
+        if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+          log.warn("auth store unreadable, treating as empty", { error })
+        }
       }
     }
 
@@ -324,6 +329,9 @@ export namespace Auth {
     const normalized = normalizeKey(key)
     const file = filepath()
     const tmp = file + ".tmp"
+    // Serialize all auth.json mutations: an unguarded read-modify-write here
+    // can drop a concurrent update (e.g. a token refresh for another provider).
+    using _ = await Lock.write("auth-file")
     try {
       const data = await allImpl()
       await Bun.write(tmp, JSON.stringify({ ...data, [normalized]: info }, null, 2))
@@ -341,6 +349,7 @@ export namespace Auth {
     const normalized = normalizeKey(key)
     const file = filepath()
     const tmp = file + ".tmp"
+    using _ = await Lock.write("auth-file")
     try {
       const data = await allImpl()
       delete data[normalized]

--- a/packages/nikcli/src/bus/index.ts
+++ b/packages/nikcli/src/bus/index.ts
@@ -142,13 +142,17 @@ export namespace Bus {
   export async function publish<Definition extends BusEvent.Definition>(
     def: Definition,
     properties: z.output<Definition["properties"]>,
-  ) {
+  ): Promise<void> {
+    // Best-effort by contract: most call sites fire-and-forget, so a rejection
+    // here must never escape as an unhandled rejection — log it instead.
     return run(
       Effect.gen(function* () {
         const bus = yield* Service
         yield* bus.publish(def, properties)
       }),
-    )
+    ).catch((error) => {
+      log.error("publish failed", { type: def.type, error })
+    })
   }
 
   export function subscribe<Definition extends BusEvent.Definition>(

--- a/packages/nikcli/src/cli/cmd/run.ts
+++ b/packages/nikcli/src/cli/cmd/run.ts
@@ -543,7 +543,12 @@ export const RunCommand = cmd({
             })
           }
         }
-      })()
+      })().catch((error) => {
+        // Stream failures must surface through the normal error path: the
+        // processor is only awaited later, after the prompt round-trips, and an
+        // unhandled interim rejection would crash the run instead.
+        errorMsg = errorMsg ? errorMsg + EOL + String(error) : String(error)
+      })
 
       const resolvedAgent = await (async () => {
         if (!args.agent) return undefined

--- a/packages/nikcli/src/cli/cmd/tui/worker.ts
+++ b/packages/nikcli/src/cli/cmd/tui/worker.ts
@@ -80,8 +80,16 @@ function startEventStream(directory: string) {
         continue
       }
 
-      for await (const event of events.stream) {
-        Rpc.emit("event", { id, event: event as Event })
+      try {
+        for await (const event of events.stream) {
+          Rpc.emit("event", { id, event: event as Event })
+        }
+      } catch (error) {
+        // A dropped stream must not kill the subscription loop — log and reconnect.
+        if (signal.aborted) return
+        Log.Default.warn("event stream interrupted, reconnecting", {
+          error: error instanceof Error ? error.message : error,
+        })
       }
 
       if (!signal.aborted) {
@@ -137,7 +145,11 @@ export const rpc = {
       directory: input.directory,
       init: InstanceBootstrap,
       fn: async () => {
-        await upgrade().catch(() => {})
+        await upgrade().catch((error) => {
+          Log.Default.debug("upgrade check failed", {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        })
       },
     })
   },

--- a/packages/nikcli/src/config/paths.ts
+++ b/packages/nikcli/src/config/paths.ts
@@ -5,6 +5,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
 import { Cause, Context, Effect, Exit, Layer, Schema } from "effect"
+import { AppRuntime } from "@/effect/runtime"
 
 export namespace ConfigPaths {
   type MissingMode = "error" | "empty"
@@ -212,7 +213,7 @@ export namespace ConfigPaths {
   export const defaultLayer = layer
 
   async function runCompat<A, E>(effect: Effect.Effect<A, E>) {
-    const exit = await Effect.runPromiseExit(effect)
+    const exit = await AppRuntime.runPromiseExit(effect)
     if (Exit.isSuccess(exit)) return exit.value
     throw Cause.squash(exit.cause)
   }

--- a/packages/nikcli/src/config/tui.ts
+++ b/packages/nikcli/src/config/tui.ts
@@ -12,7 +12,7 @@ import { isRecord } from "@/util/record"
 import { Global } from "@/global"
 import { parsePluginSpecifier } from "@/plugin/shared"
 import { Effect } from "effect"
-import { InstanceState, type InstanceContext } from "@/effect"
+import { InstanceState, runPromiseWithLayer, type InstanceContext } from "@/effect"
 import { Filesystem } from "@/util/filesystem"
 
 export namespace TuiConfig {
@@ -177,7 +177,7 @@ export namespace TuiConfig {
   })
 
   const state = Instance.state(async () => {
-    return Effect.runPromise(loadState().pipe(Effect.provide(ConfigPaths.defaultLayer)))
+    return runPromiseWithLayer(ConfigPaths.defaultLayer, loadState())
   })
 
   export async function get() {

--- a/packages/nikcli/src/delegation/manager.ts
+++ b/packages/nikcli/src/delegation/manager.ts
@@ -406,7 +406,9 @@ export namespace Delegation {
               const sessionPrompt = yield* SessionPrompt.Service
               yield* sessionPrompt.cancel(record.sessionID!)
             }),
-          )
+          ).catch((error) => {
+            log.warn("failed to cancel session for timed out delegation", { delegationID, error })
+          })
         }
         scheduleForcedFinalize(delegationID, "timeout", "Timed out")
       } catch (err) {
@@ -427,6 +429,7 @@ export namespace Delegation {
         })
       })
     }, BackgroundRun.LEASE_TIMEOUT_MS)
+    entry.reconcileTimer.unref()
   }
 
   export async function create(params: CreateParams): Promise<Record> {
@@ -780,9 +783,13 @@ export namespace Delegation {
       }
 
       const check = () => {
-        void hasRunningDelegations().then((running) => {
-          if (!running) finish()
-        })
+        void hasRunningDelegations()
+          .then((running) => {
+            if (!running) finish()
+          })
+          .catch((error) => {
+            log.warn("failed to check running delegations", { parentSessionID, error })
+          })
       }
 
       const timer = setTimeout(finish, timeoutMs)
@@ -829,9 +836,13 @@ export namespace Delegation {
       }
 
       const check = () => {
-        void hasRunningDelegations().then((running) => {
-          if (!running) finish()
-        })
+        void hasRunningDelegations()
+          .then((running) => {
+            if (!running) finish()
+          })
+          .catch((error) => {
+            log.warn("failed to check running delegations", { jobID, error })
+          })
       }
 
       const timer = setTimeout(finish, timeoutMs)

--- a/packages/nikcli/src/effect/instance-scope.ts
+++ b/packages/nikcli/src/effect/instance-scope.ts
@@ -1,6 +1,7 @@
 import { Instance } from "@/project/instance"
 import { Cause, Effect, Exit } from "effect"
 import { locallyInstance, locallyWorkspace, type InstanceContext } from "./instance-ref"
+import { AppRuntime } from "./runtime"
 
 export interface WithInput {
   readonly directory: string
@@ -22,7 +23,7 @@ export const InstanceScope = {
             const scoped = input.workspaceID
               ? locallyWorkspace({ id: input.workspaceID }, locallyInstance(ctx, effect))
               : locallyInstance(ctx, effect)
-            const exit = await Effect.runPromiseExit(scoped as Effect.Effect<A, E, never>)
+            const exit = await AppRuntime.runPromiseExit(scoped as Effect.Effect<A, E, never>)
             if (Exit.isSuccess(exit)) return exit.value
             throw Cause.squash(exit.cause)
           },

--- a/packages/nikcli/src/effect/with-instance.ts
+++ b/packages/nikcli/src/effect/with-instance.ts
@@ -24,7 +24,7 @@ import { InstanceScope, type WithInput } from "./instance-scope"
  * Use this at the outermost entry boundary, not inside per-operation helpers.
  */
 export function withInstance<A, E, R>(input: WithInput, effect: Effect.Effect<A, E, R>): Promise<A> {
-  return AppRuntime.runPromise(InstanceScope.with(input, effect) as Effect.Effect<A, unknown, never>) as Promise<A>
+  return AppRuntime.runPromise(InstanceScope.with(input, effect))
 }
 
 /**

--- a/packages/nikcli/src/image/image.ts
+++ b/packages/nikcli/src/image/image.ts
@@ -99,13 +99,71 @@ export namespace Image {
             },
           })
 
-          try {
-            const originalWidth = decoded.get_width()
-            const originalHeight = decoded.get_height()
-            if (originalWidth <= info.maxWidth && originalHeight <= info.maxHeight && bytes <= info.maxBase64Bytes)
-              return input
-            if (!info.autoResize)
-              return yield* new SizeError({
+          // The resize work is fully synchronous, so it runs in a plain function
+          // where try/finally reliably frees the wasm image. (A finally around a
+          // failing `yield*` inside Effect.gen never runs — the runtime abandons
+          // the iterator on failure — which leaked `decoded` on the error paths.)
+          const outcome = ((): MessageV2.FilePart | SizeError => {
+            try {
+              const originalWidth = decoded.get_width()
+              const originalHeight = decoded.get_height()
+              if (originalWidth <= info.maxWidth && originalHeight <= info.maxHeight && bytes <= info.maxBase64Bytes)
+                return input
+              if (!info.autoResize)
+                return new SizeError({
+                  bytes,
+                  max: info.maxBase64Bytes,
+                  width: originalWidth,
+                  height: originalHeight,
+                  max_width: info.maxWidth,
+                  max_height: info.maxHeight,
+                })
+
+              const scale = Math.min(1, info.maxWidth / originalWidth, info.maxHeight / originalHeight)
+              for (const size of Array.from({ length: 32 }).reduce<Array<{ width: number; height: number }>>((acc) => {
+                const previous = acc.at(-1) ?? {
+                  width: Math.max(1, Math.round(originalWidth * scale)),
+                  height: Math.max(1, Math.round(originalHeight * scale)),
+                }
+                const next =
+                  acc.length === 0
+                    ? previous
+                    : {
+                        width: previous.width === 1 ? 1 : Math.max(1, Math.floor(previous.width * 0.75)),
+                        height: previous.height === 1 ? 1 : Math.max(1, Math.floor(previous.height * 0.75)),
+                      }
+                return acc.some((item) => item.width === next.width && item.height === next.height)
+                  ? acc
+                  : [...acc, next]
+              }, [])) {
+                const resized = photon.resize(decoded, size.width, size.height, photon.SamplingFilter.Lanczos3)
+                const candidate = [
+                  { data: Buffer.from(resized.get_bytes()).toString("base64"), mime: "image/png" },
+                  ...JPEG_QUALITIES.map((quality) => ({
+                    data: Buffer.from(resized.get_bytes_jpeg(quality)).toString("base64"),
+                    mime: "image/jpeg",
+                  })),
+                ]
+                  .map((item) => ({ ...item, bytes: Buffer.byteLength(item.data, "utf8") }))
+                  .find((item) => item.bytes <= info.maxBase64Bytes)
+                resized.free()
+
+                if (candidate) {
+                  log.info("using resized image", {
+                    from_mime: input.mime,
+                    to_mime: candidate.mime,
+                    from: `${originalWidth}x${originalHeight}`,
+                    to: `${size.width}x${size.height}`,
+                  })
+                  return {
+                    ...input,
+                    mime: candidate.mime,
+                    url: `data:${candidate.mime};base64,${candidate.data}`,
+                  }
+                }
+              }
+
+              return new SizeError({
                 bytes,
                 max: info.maxBase64Bytes,
                 width: originalWidth,
@@ -113,60 +171,12 @@ export namespace Image {
                 max_width: info.maxWidth,
                 max_height: info.maxHeight,
               })
-
-            const scale = Math.min(1, info.maxWidth / originalWidth, info.maxHeight / originalHeight)
-            for (const size of Array.from({ length: 32 }).reduce<Array<{ width: number; height: number }>>((acc) => {
-              const previous = acc.at(-1) ?? {
-                width: Math.max(1, Math.round(originalWidth * scale)),
-                height: Math.max(1, Math.round(originalHeight * scale)),
-              }
-              const next =
-                acc.length === 0
-                  ? previous
-                  : {
-                      width: previous.width === 1 ? 1 : Math.max(1, Math.floor(previous.width * 0.75)),
-                      height: previous.height === 1 ? 1 : Math.max(1, Math.floor(previous.height * 0.75)),
-                    }
-              return acc.some((item) => item.width === next.width && item.height === next.height) ? acc : [...acc, next]
-            }, [])) {
-              const resized = photon.resize(decoded, size.width, size.height, photon.SamplingFilter.Lanczos3)
-              const candidate = [
-                { data: Buffer.from(resized.get_bytes()).toString("base64"), mime: "image/png" },
-                ...JPEG_QUALITIES.map((quality) => ({
-                  data: Buffer.from(resized.get_bytes_jpeg(quality)).toString("base64"),
-                  mime: "image/jpeg",
-                })),
-              ]
-                .map((item) => ({ ...item, bytes: Buffer.byteLength(item.data, "utf8") }))
-                .find((item) => item.bytes <= info.maxBase64Bytes)
-              resized.free()
-
-              if (candidate) {
-                log.info("using resized image", {
-                  from_mime: input.mime,
-                  to_mime: candidate.mime,
-                  from: `${originalWidth}x${originalHeight}`,
-                  to: `${size.width}x${size.height}`,
-                })
-                return {
-                  ...input,
-                  mime: candidate.mime,
-                  url: `data:${candidate.mime};base64,${candidate.data}`,
-                }
-              }
+            } finally {
+              decoded.free()
             }
-
-            return yield* new SizeError({
-              bytes,
-              max: info.maxBase64Bytes,
-              width: originalWidth,
-              height: originalHeight,
-              max_width: info.maxWidth,
-              max_height: info.maxHeight,
-            })
-          } finally {
-            decoded.free()
-          }
+          })()
+          if (outcome instanceof SizeError) return yield* outcome
+          return outcome
         })
 
       return Service.of({ normalize })

--- a/packages/nikcli/src/project/bootstrap.ts
+++ b/packages/nikcli/src/project/bootstrap.ts
@@ -35,6 +35,14 @@ function runLSP<A, E>(effect: Effect.Effect<A, E, LSP.Service>) {
   return runPromiseWithLayer(LSP.defaultLayer, withCurrentInstance(effect))
 }
 
+// Startup inits that must not block instance creation run fire-and-forget,
+// but a rejected promise must never escape as an unhandled rejection.
+function background(service: string, promise: Promise<unknown>) {
+  void promise.catch((error) => {
+    Log.Default.warn("background init failed", { service, error })
+  })
+}
+
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await runPlugin(
@@ -43,20 +51,26 @@ export async function InstanceBootstrap() {
       yield* plugin.init()
     }),
   )
-  void runPromiseWithLayer(
-    ShareNext.defaultLayer,
-    Effect.gen(function* () {
-      const shareNext = yield* ShareNext.Service
-      yield* shareNext.init()
-    }),
-  )
-  void runPromiseWithLayer(
-    Format.defaultLayer,
-    withCurrentInstance(
+  background(
+    "share",
+    runPromiseWithLayer(
+      ShareNext.defaultLayer,
       Effect.gen(function* () {
-        const format = yield* Format.Service
-        yield* format.init()
+        const shareNext = yield* ShareNext.Service
+        yield* shareNext.init()
       }),
+    ),
+  )
+  background(
+    "format",
+    runPromiseWithLayer(
+      Format.defaultLayer,
+      withCurrentInstance(
+        Effect.gen(function* () {
+          const format = yield* Format.Service
+          yield* format.init()
+        }),
+      ),
     ),
   )
   await runLSP(
@@ -65,53 +79,71 @@ export async function InstanceBootstrap() {
       yield* lsp.init()
     }),
   )
-  void runPromiseWithLayer(
-    FileWatcher.defaultLayer,
-    withCurrentInstance(
+  background(
+    "file-watcher",
+    runPromiseWithLayer(
+      FileWatcher.defaultLayer,
+      withCurrentInstance(
+        Effect.gen(function* () {
+          const fileWatcher = yield* FileWatcher.Service
+          yield* fileWatcher.init()
+        }),
+      ),
+    ),
+  )
+  background(
+    "file",
+    runFile(
       Effect.gen(function* () {
-        const fileWatcher = yield* FileWatcher.Service
-        yield* fileWatcher.init()
+        const file = yield* File.Service
+        yield* file.init()
       }),
     ),
   )
-  void runFile(
-    Effect.gen(function* () {
-      const file = yield* File.Service
-      yield* file.init()
-    }),
+  background(
+    "vcs",
+    runPromiseWithLayer(
+      Vcs.defaultLayer,
+      withCurrentInstance(
+        Effect.gen(function* () {
+          const vcs = yield* Vcs.Service
+          yield* vcs.init()
+        }),
+      ),
+    ),
   )
-  void runPromiseWithLayer(
-    Vcs.defaultLayer,
-    withCurrentInstance(
+  background(
+    "snapshot",
+    runPromiseWithLayer(
+      Snapshot.defaultLayer,
+      withCurrentInstance(
+        Effect.gen(function* () {
+          const snapshot = yield* Snapshot.Service
+          yield* snapshot.init()
+        }),
+      ),
+    ),
+  )
+  background(
+    "truncate",
+    runPromiseWithLayer(
+      Truncate.defaultLayer,
       Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        yield* vcs.init()
+        const truncate = yield* Truncate.Service
+        yield* truncate.init()
       }),
     ),
   )
-  void runPromiseWithLayer(
-    Snapshot.defaultLayer,
-    withCurrentInstance(
-      Effect.gen(function* () {
-        const snapshot = yield* Snapshot.Service
-        yield* snapshot.init()
-      }),
-    ),
-  )
-  void runPromiseWithLayer(
-    Truncate.defaultLayer,
-    Effect.gen(function* () {
-      const truncate = yield* Truncate.Service
-      yield* truncate.init()
-    }),
-  )
-  void runPromiseWithLayer(
-    Todo.defaultLayer,
-    withCurrentInstance(
-      Effect.gen(function* () {
-        const todo = yield* Todo.Service
-        yield* todo.init()
-      }),
+  background(
+    "todo",
+    runPromiseWithLayer(
+      Todo.defaultLayer,
+      withCurrentInstance(
+        Effect.gen(function* () {
+          const todo = yield* Todo.Service
+          yield* todo.init()
+        }),
+      ),
     ),
   )
   await Delegation.init()

--- a/packages/nikcli/src/provider/models.ts
+++ b/packages/nikcli/src/provider/models.ts
@@ -279,4 +279,8 @@ export namespace ModelsDev {
   }
 }
 
-setInterval(() => ModelsDev.refresh(), 60 * 1000 * 60).unref()
+setInterval(() => {
+  ModelsDev.refresh().catch((error) => {
+    Log.Default.error("scheduled models.dev refresh failed", { error })
+  })
+}, 60 * 1000 * 60).unref()

--- a/packages/nikcli/src/provider/models.ts
+++ b/packages/nikcli/src/provider/models.ts
@@ -234,7 +234,9 @@ export namespace ModelsDev {
 
   export async function get() {
     if (!Flag.NIKCLI_DISABLE_MODELS_FETCH) {
-      refresh()
+      refresh().catch((error) => {
+        log.error("background models refresh failed", { error })
+      })
     }
     const file = Bun.file(filepath)
     const result = await file.json().catch(() => {})
@@ -250,12 +252,18 @@ export namespace ModelsDev {
     if (Flag.NIKCLI_DISABLE_MODELS_FETCH) return {}
     const url = Global.Path.modelsDevUrl
     const json = await fetch(`${url}/api.json`)
-      .then((x) => x.text())
+      .then((x) => (x.ok ? x.text() : "{}"))
       .catch((error) => {
         log.error("Failed to fetch models.dev", { error })
         return "{}"
       })
-    return patch(JSON.parse(json) as Record<string, Provider>)
+    try {
+      return patch(JSON.parse(json) as Record<string, Provider>)
+    } catch (error) {
+      // Captive portals / proxies can return a 200 with a non-JSON body.
+      log.error("models.dev returned invalid JSON", { error })
+      return {}
+    }
   }
 
   export async function refresh() {

--- a/packages/nikcli/src/provider/provider.ts
+++ b/packages/nikcli/src/provider/provider.ts
@@ -13,7 +13,7 @@ import { Env } from "../env"
 import { Flag } from "../flag/flag"
 import { iife } from "@/util/iife"
 import { type DeepMutable, zodObject } from "@/util/effect-zod"
-import { Context, Effect, Layer, Schema, ScopedCache } from "effect"
+import { Context, Effect, Exit, Layer, Schema, ScopedCache } from "effect"
 import {
   InstanceState,
   locallyInstance,
@@ -1070,14 +1070,22 @@ export namespace Provider {
     log.info("init")
 
     // Auto-detect local Ollama and expose it as a provider when available.
-    const ollama = await loadOllamaProvider(config).catch(() => undefined)
+    const ollama = await loadOllamaProvider(config).catch((error) => {
+      log.debug("ollama provider unavailable", { error: error instanceof Error ? error.message : String(error) })
+      return undefined
+    })
     if (ollama && isProviderAllowed(ollama.id)) {
       providers[ollama.id] = ollama
     }
 
     // Auto-detect the nikcli inference gateway (default: https://inference.nikcli.store/v1).
     // Set NIKCLI_INFERENCE_KEY (or config.provider.nikcli-inference.options.apiKey) to enable.
-    const nikcliInference = await loadNikcliInferenceProvider(config).catch(() => undefined)
+    const nikcliInference = await loadNikcliInferenceProvider(config).catch((error) => {
+      log.debug("nikcli inference provider unavailable", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return undefined
+    })
     if (nikcliInference && isProviderAllowed(nikcliInference.id)) {
       providers[nikcliInference.id] = nikcliInference
     }
@@ -1877,13 +1885,13 @@ export namespace Provider {
         const s = yield* getState()
         const provider = s.providers[providerID]
         if (provider) {
-          if (providerID.startsWith("nikcli"))
-            if (providerID.startsWith("github-copilot"))
-              for (const item of priority) {
-                for (const model of Object.keys(provider.models)) {
-                  if (model.includes(item)) return yield* getModelEffect(providerID, model)
-                }
+          if (providerID.startsWith("nikcli") || providerID.startsWith("github-copilot")) {
+            for (const item of priority) {
+              for (const model of Object.keys(provider.models)) {
+                if (model.includes(item)) return yield* getModelEffect(providerID, model)
               }
+            }
+          }
         }
 
         const nikcliProvider = s.providers["nikcli"]
@@ -1937,12 +1945,12 @@ export namespace Provider {
       const refresh: Interface["refresh"] = Effect.fn("Provider.refresh")(function* () {
         // Clear the cached LanguageModel instances built from the old SDK +
         // auth before invalidating, so the next getLanguage() rebuilds them.
-        try {
-          const s = yield* getState()
-          s.models.clear()
-          s.sdk.clear()
-        } catch {
-          // state never built yet — nothing to clear
+        // Effect failures don't surface as JS exceptions inside Effect.gen, so
+        // capture the Exit instead of a try/catch (state may not be built yet).
+        const stateExit = yield* Effect.exit(getState())
+        if (Exit.isSuccess(stateExit)) {
+          stateExit.value.models.clear()
+          stateExit.value.sdk.clear()
         }
         // Invalidate every cached directory entry, not just the current one.
         // Auth (`auth.json`) and config live in global/shared locations, so a

--- a/packages/nikcli/src/server/routes/global.ts
+++ b/packages/nikcli/src/server/routes/global.ts
@@ -82,14 +82,18 @@ export const GlobalRoutes = lazy(() =>
 
           // Send heartbeat every 30s to prevent WKWebView timeout (60s default)
           const heartbeat = setInterval(() => {
-            stream.writeSSE({
-              data: JSON.stringify({
-                payload: {
-                  type: "server.heartbeat",
-                  properties: {},
-                },
-              }),
-            })
+            stream
+              .writeSSE({
+                data: JSON.stringify({
+                  payload: {
+                    type: "server.heartbeat",
+                    properties: {},
+                  },
+                }),
+              })
+              .catch((error) => {
+                log.debug("sse heartbeat failed", { error })
+              })
           }, 30000)
 
           await new Promise<void>((resolve) => {

--- a/packages/nikcli/src/server/routes/mobile.ts
+++ b/packages/nikcli/src/server/routes/mobile.ts
@@ -53,7 +53,7 @@ import { generateFromDescription as generateLoopFromDescription } from "./loop"
 import { lazy } from "@/util/lazy"
 import { Log } from "@/util/log"
 import { Effect } from "effect"
-import { InstanceScope, runPromiseWithLayer, withCurrentInstance, withInstanceAsync } from "@/effect"
+import { runPromiseWithLayer, withCurrentInstance, withInstance, withInstanceAsync } from "@/effect"
 
 const log = Log.create({ service: "mobile-routes" })
 
@@ -73,11 +73,9 @@ function runCommandForSession<A, E>(
   session: Pick<Session.Info, "directory" | "workspaceID">,
   effect: Effect.Effect<A, E, Command.Service>,
 ) {
-  return Effect.runPromise(
-    InstanceScope.with(
-      { directory: session.directory, workspaceID: session.workspaceID },
-      Effect.provide(effect, Command.defaultLayer),
-    ),
+  return withInstance(
+    { directory: session.directory, workspaceID: session.workspaceID },
+    Effect.provide(effect, Command.defaultLayer),
   )
 }
 
@@ -89,11 +87,9 @@ function runStatusForSession<A, E>(
   session: Pick<Session.Info, "directory" | "workspaceID">,
   effect: Effect.Effect<A, E, SessionStatus.Service>,
 ) {
-  return Effect.runPromise(
-    InstanceScope.with(
-      { directory: session.directory, workspaceID: session.workspaceID },
-      Effect.provide(effect, SessionStatus.defaultLayer),
-    ),
+  return withInstance(
+    { directory: session.directory, workspaceID: session.workspaceID },
+    Effect.provide(effect, SessionStatus.defaultLayer),
   )
 }
 
@@ -101,11 +97,9 @@ function runSessionPromptForSession<A, E>(
   session: Pick<Session.Info, "directory" | "workspaceID">,
   effect: Effect.Effect<A, E, SessionPrompt.Service>,
 ) {
-  return Effect.runPromise(
-    InstanceScope.with(
-      { directory: session.directory, workspaceID: session.workspaceID },
-      Effect.provide(effect, SessionPrompt.defaultLayer),
-    ),
+  return withInstance(
+    { directory: session.directory, workspaceID: session.workspaceID },
+    Effect.provide(effect, SessionPrompt.defaultLayer),
   )
 }
 
@@ -117,11 +111,9 @@ function runSessionForSession<A, E>(
   session: Pick<Session.Info, "directory" | "workspaceID">,
   effect: Effect.Effect<A, E, Session.Service>,
 ) {
-  return Effect.runPromise(
-    InstanceScope.with(
-      { directory: session.directory, workspaceID: session.workspaceID },
-      Effect.provide(effect, Session.defaultLayer),
-    ),
+  return withInstance(
+    { directory: session.directory, workspaceID: session.workspaceID },
+    Effect.provide(effect, Session.defaultLayer),
   )
 }
 
@@ -142,7 +134,7 @@ function runWorktree<A, E>(effect: Effect.Effect<A, E, Worktree.Service>) {
 }
 
 function runWorktreeForDirectory<A, E>(directory: string, effect: Effect.Effect<A, E, Worktree.Service>) {
-  return Effect.runPromise(InstanceScope.with({ directory }, Effect.provide(effect, Worktree.defaultLayer)))
+  return withInstance({ directory }, Effect.provide(effect, Worktree.defaultLayer))
 }
 
 function runConnectorAuth<A, E>(effect: Effect.Effect<A, E, ConnectorAuth.Service>) {
@@ -2599,9 +2591,13 @@ export const MobileRoutes = lazy(() =>
           GlobalBus.on("event", onEvent)
 
           const heartbeat = setInterval(() => {
-            void stream.writeSSE({
-              data: JSON.stringify({ type: "server.heartbeat", properties: { sessionID } }),
-            })
+            stream
+              .writeSSE({
+                data: JSON.stringify({ type: "server.heartbeat", properties: { sessionID } }),
+              })
+              .catch((error) => {
+                log.debug("sse heartbeat failed", { sessionID, error })
+              })
           }, 30000)
 
           await new Promise<void>((resolve) => {
@@ -3652,7 +3648,9 @@ export const MobileRoutes = lazy(() =>
         return withInstanceAsync({ directory: Instance.directory }, async () => {
           const { id } = c.req.valid("param")
           if (!(await LoopManager.get(id))) return c.json({ error: `Loop "${id}" not found` }, 404)
-          void LoopEngine.runOnce(id)
+          void LoopEngine.runOnce(id).catch((error) => {
+          log.error("loop run failed", { id, error })
+        })
           return c.json({ success: true as const })
         })
       },

--- a/packages/nikcli/src/server/routes/pty.ts
+++ b/packages/nikcli/src/server/routes/pty.ts
@@ -8,6 +8,9 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { runPromiseWithLayer, withCurrentInstance } from "@/effect"
 import { Effect } from "effect"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "pty-routes" })
 
 function runPty<A, E>(effect: Effect.Effect<A, E, Pty.Service>) {
   return runPromiseWithLayer(Pty.defaultLayer, withCurrentInstance(effect))
@@ -214,10 +217,14 @@ export const PtyRoutes = lazy(() =>
                       const pty = yield* Pty.Service
                       yield* pty.resize(id, msg.cols as number, msg.rows as number)
                     }),
-                  )
+                  ).catch((error) => {
+                    log.warn("pty resize failed", { id, error })
+                  })
                   return
                 }
-              } catch {}
+              } catch {
+                // Not a JSON control message — fall through and treat it as PTY input.
+              }
             }
             handler?.onMessage(text)
           },

--- a/packages/nikcli/src/server/server.ts
+++ b/packages/nikcli/src/server/server.ts
@@ -1061,12 +1061,16 @@ export namespace Server {
 
               // Send heartbeat every 30s to prevent WKWebView timeout (60s default)
               const heartbeat = setInterval(() => {
-                stream.writeSSE({
-                  data: JSON.stringify({
-                    type: "server.heartbeat",
-                    properties: {},
-                  }),
-                })
+                stream
+                  .writeSSE({
+                    data: JSON.stringify({
+                      type: "server.heartbeat",
+                      properties: {},
+                    }),
+                  })
+                  .catch((error) => {
+                    log.debug("sse heartbeat failed", { error })
+                  })
               }, 30000)
 
               await new Promise<void>((resolve) => {

--- a/packages/nikcli/src/session/context-breakdown.ts
+++ b/packages/nikcli/src/session/context-breakdown.ts
@@ -11,7 +11,7 @@ import { Agent } from "@/agent/agent"
 import { Skill } from "@/skill"
 import { Token } from "@/util/token"
 import { Log } from "@/util/log"
-import { runPromiseWithLayer, withCurrentInstance, InstanceState, type InstanceContext } from "@/effect"
+import { AppRuntime, runPromiseWithLayer, withCurrentInstance, InstanceState, type InstanceContext } from "@/effect"
 import { collectSystemPaths } from "./instruction"
 
 const log = Log.create({ service: "session.context-breakdown" })
@@ -79,7 +79,7 @@ export namespace SessionContext {
   }
 
   function currentContext(): Promise<InstanceContext> {
-    return Effect.runPromise(withCurrentInstance(InstanceState.context))
+    return AppRuntime.runPromise(withCurrentInstance(InstanceState.context))
   }
 
   const est = (s: string) => Token.estimate(s)

--- a/packages/nikcli/src/session/index.ts
+++ b/packages/nikcli/src/session/index.ts
@@ -525,8 +525,9 @@ export namespace Session {
             draft.share = share
           })
         })
-        .catch(() => {
-          // Silently ignore sharing errors during session creation
+        .catch((error) => {
+          // Auto-share is best-effort during session creation, but keep a trace.
+          log.warn("failed to auto-share session", { sessionID: result.id, error })
         })
     await publishBus(ctx, Event.Updated, {
       info: result,

--- a/packages/nikcli/src/session/mode.ts
+++ b/packages/nikcli/src/session/mode.ts
@@ -1,7 +1,8 @@
 import z from "zod"
 import { Config } from "../config/config"
 import { Effect } from "effect"
-import { InstanceState, runPromiseWithLayer, withCurrentInstance } from "@/effect"
+import { AppRuntime, InstanceState, runPromiseWithLayer, withCurrentInstance } from "@/effect"
+import { Instance } from "@/project/instance"
 import { Provider } from "@/provider/provider"
 
 export namespace Mode {
@@ -77,10 +78,14 @@ export namespace Mode {
     }),
   )
 
-  let cache: Record<string, Info> | undefined
+  // Modes are derived from per-instance config, so the memo must be keyed by
+  // directory — a single process can host multiple instances.
+  const cache = new Map<string, Record<string, Info>>()
 
   async function load() {
-    if (cache) return cache
+    const directory = Instance.directory
+    const existing = cache.get(directory)
+    if (existing) return existing
     const effect = Effect.scoped(
       Effect.gen(function* () {
         const handle = yield* facade
@@ -88,8 +93,9 @@ export namespace Mode {
         return value
       }),
     )
-    cache = await Effect.runPromise(effect)
-    return cache
+    const value = await AppRuntime.runPromise(effect)
+    cache.set(directory, value)
+    return value
   }
 
   export async function get(mode: string) {

--- a/packages/nikcli/src/session/prompt.ts
+++ b/packages/nikcli/src/session/prompt.ts
@@ -44,7 +44,14 @@ import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Context, Effect, Layer, ScopedCache } from "effect"
 import { Instance } from "@/project/instance"
-import { InstanceState, runPromiseWithLayer, runtimeFor, withCurrentInstance, type InstanceContext } from "@/effect"
+import {
+  AppRuntime,
+  InstanceState,
+  runPromiseWithLayer,
+  runtimeFor,
+  withCurrentInstance,
+  type InstanceContext,
+} from "@/effect"
 import { errorMessage } from "@/util/error"
 import { resolveTools, createStructuredOutputTool } from "./tools"
 
@@ -356,7 +363,7 @@ export namespace SessionPrompt {
   }
 
   function currentContext(): Promise<InstanceContext> {
-    return Effect.runPromise(withCurrentInstance(InstanceState.context))
+    return AppRuntime.runPromise(withCurrentInstance(InstanceState.context))
   }
 
   function runInInstanceContext<A>(ctx: InstanceContext, fn: () => Promise<A>): Effect.Effect<A, Error> {

--- a/packages/nikcli/src/session/summary.ts
+++ b/packages/nikcli/src/session/summary.ts
@@ -10,7 +10,7 @@ import { LLM } from "./llm"
 import { Agent } from "@/agent/agent"
 import { zodObject } from "@/util/effect-zod"
 import { Context, Effect, Layer, Schema } from "effect"
-import { InstanceState, locallyInstance, runPromiseWithLayer, type InstanceContext } from "@/effect"
+import { AppRuntime, InstanceState, locallyInstance, runPromiseWithLayer, type InstanceContext } from "@/effect"
 
 export namespace SessionSummary {
   const log = Log.create({ service: "session.summary" })
@@ -141,7 +141,7 @@ export namespace SessionSummary {
             .flatMap((x) => x.files)
             .map((x) => path.relative(ctx.worktree, x)),
         )
-        const diffs = (await Effect.runPromise(computeDiff({ messages: input.messages }))).filter((x) => {
+        const diffs = (await AppRuntime.runPromise(locallyInstance(ctx, computeDiff({ messages: input.messages })))).filter((x) => {
           return files.has(x.file)
         })
         await runSession(
@@ -178,7 +178,7 @@ export namespace SessionSummary {
         const msgWithParts = messages.find((message) => message.info.id === rootID)
         if (!msgWithParts || msgWithParts.info.role !== "user") return
         const userMsg = msgWithParts.info as MessageV2.User
-        const diffs = await Effect.runPromise(computeDiff({ messages }))
+        const diffs = await AppRuntime.runPromise(locallyInstance(ctx, computeDiff({ messages })))
         userMsg.summary = {
           ...userMsg.summary,
           diffs,
@@ -193,7 +193,7 @@ export namespace SessionSummary {
 
         const textPart = msgWithParts.parts.find((p) => p.type === "text" && !p.synthetic) as MessageV2.TextPart
         if (textPart && userMsg.summary?.title === undefined) {
-          const agent = await Effect.runPromise(agentService.get("title"))
+          const agent = await AppRuntime.runPromise(locallyInstance(ctx, agentService.get("title")))
           if (!agent) return
           const model = await runProvider(
             Effect.gen(function* () {

--- a/packages/nikcli/src/session/system.ts
+++ b/packages/nikcli/src/session/system.ts
@@ -12,7 +12,7 @@ import PROMPT_TITLE from "./prompt/title.txt"
 import type { Provider } from "@/provider/provider"
 import { Skill } from "@/skill"
 import { Context, Effect, Layer } from "effect"
-import { InstanceState, locallyInstance, runPromiseWithLayer, type InstanceContext } from "@/effect"
+import { AppRuntime, InstanceState, locallyInstance, runPromiseWithLayer, type InstanceContext } from "@/effect"
 
 const log = Log.create({ service: "system-prompt" })
 
@@ -107,7 +107,14 @@ export namespace SystemPrompt {
     if (uniqueNames.length === 0) return []
 
     const loaded = (
-      await Promise.all(uniqueNames.map((name) => Effect.runPromise(skill.load(name)).catch(() => undefined)))
+      await Promise.all(
+        uniqueNames.map((name) =>
+          AppRuntime.runPromise(skill.load(name)).catch((error) => {
+            log.warn("failed to load skill for system prompt", { name, error })
+            return undefined
+          }),
+        ),
+      )
     ).filter((skill): skill is Skill.Loaded => !!skill)
 
     if (loaded.length === 0) return []

--- a/packages/nikcli/src/share/share.ts
+++ b/packages/nikcli/src/share/share.ts
@@ -27,7 +27,10 @@ export namespace Share {
         const session = yield* Session.Service
         return yield* session.getShare(sessionID)
       }),
-    ).catch(() => {})
+    ).catch((error) => {
+      log.debug("share lookup failed", { sessionID, error })
+      return undefined
+    })
     if (!share) return
     const { secret } = share
     pending.set(key, content)
@@ -54,6 +57,11 @@ export namespace Share {
             status: x.status,
           })
         }
+      })
+      .catch((error) => {
+        // A failed sync must not poison the queue: a rejected `queue` promise
+        // would make every later sync skip its .then() chain permanently.
+        log.warn("share sync failed", { key, error })
       })
   }
 

--- a/packages/nikcli/src/tool/advisor.ts
+++ b/packages/nikcli/src/tool/advisor.ts
@@ -6,6 +6,9 @@ import DESCRIPTION from "./advisor.txt"
 import { Delegation } from "@/delegation/manager"
 import { Effect } from "effect"
 import { runPromiseWithLayer, withCurrentInstance } from "@/effect"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "tool.advisor" })
 
 const parameters = z.object({
   context: z
@@ -98,6 +101,14 @@ export const AdvisorTool = Tool.define<typeof parameters, AdvisorMetadata>("advi
         .catch(async (error) => {
           if (ctx.abort.aborted) return
           await Delegation.finalize(delegation.id, "error", "", error instanceof Error ? error.message : String(error))
+        })
+        .catch((error) => {
+          // Terminal guard: Delegation.finalize itself can reject; don't let it
+          // escape as an unhandled rejection from this fire-and-forget chain.
+          log.error("advisor delegation finalize failed", {
+            delegationID: delegation.id,
+            error: error instanceof Error ? error.message : String(error),
+          })
         })
 
       return {

--- a/packages/nikcli/src/tool/read.ts
+++ b/packages/nikcli/src/tool/read.ts
@@ -151,7 +151,7 @@ export const ReadTool = Tool.define("read", {
         yield* lsp.touchFile(filepath, false)
       }),
     )
-    FileTime.read(ctx.sessionID, filepath)
+    await FileTime.read(ctx.sessionID, filepath)
 
     return {
       title,

--- a/packages/nikcli/src/tool/task.ts
+++ b/packages/nikcli/src/tool/task.ts
@@ -855,6 +855,14 @@ async function launchBackgroundSubtask(params: {
         parentAgent: params.parentAgent,
       })
     })
+    .catch((error) => {
+      // Terminal guard: the error path above can itself reject (finalize/wake),
+      // which would otherwise surface as an unhandled rejection.
+      log.error("background delegation error handling failed", {
+        delegationID: delegation.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
 
   return {
     jobId: delegation.jobID!,

--- a/packages/nikcli/src/tool/tool.ts
+++ b/packages/nikcli/src/tool/tool.ts
@@ -3,7 +3,7 @@ import type { MessageV2 } from "../session/message-v2"
 import type { Agent } from "../agent/agent"
 import type { PermissionNext } from "../permission/next"
 import { Truncate } from "./truncation"
-import { runPromiseWithLayer } from "@/effect"
+import { AppRuntime, runPromiseWithLayer } from "@/effect"
 import { Effect } from "effect"
 
 export namespace Tool {
@@ -61,7 +61,7 @@ export namespace Tool {
     /**
      * Compatibility Promise wrapper. Always present so legacy callers can keep using
      * `await tool.executeAsync(args, ctx)` while the codebase migrates to Effect-native
-     * call sites. Thin wrapper around `Effect.runPromise(execute(args, ctx))`.
+     * call sites. Thin wrapper around `AppRuntime.runPromise(execute(args, ctx))`.
      */
     executeAsync(args: z.infer<Parameters>, ctx: Context): Promise<Result<M>>
     formatValidationError?(error: z.ZodError): string
@@ -147,13 +147,14 @@ export namespace Tool {
             const result = yield* asEffect(authoredExecute(args, wrappedCtx)) as Effect.Effect<Result<M>, Error>
             if (result.metadata.truncated !== undefined) return result
 
-            const truncated = yield* Effect.gen(function* () {
-              try {
-                return yield* Effect.promise(() => truncateOutput(result.output, {}, initCtx?.agent))
-              } catch {
-                return { content: result.output, truncated: false } satisfies Truncate.Result
-              }
-            })
+            // Truncation is best-effort: fall back to the raw output if it fails.
+            // (A try/catch around `yield*` would not see Effect failures, and a
+            // rejected Effect.promise would kill the fiber as a defect.)
+            const truncated = yield* Effect.promise(() =>
+              truncateOutput(result.output, {}, initCtx?.agent).catch(
+                () => ({ content: result.output, truncated: false }) satisfies Truncate.Result,
+              ),
+            )
             return {
               ...result,
               output: truncated.content,
@@ -169,7 +170,7 @@ export namespace Tool {
           description: authored.description,
           parameters: authored.parameters,
           execute,
-          executeAsync: (args, ctx) => Effect.runPromise(execute(args, ctx)),
+          executeAsync: (args, ctx) => AppRuntime.runPromise(execute(args, ctx)),
           formatValidationError: authored.formatValidationError,
         }
         return def

--- a/packages/nikcli/src/tool/truncation.ts
+++ b/packages/nikcli/src/tool/truncation.ts
@@ -4,6 +4,7 @@ import type { Agent } from "../agent/agent"
 import { Scheduler } from "../scheduler"
 import { DIR as TruncationDir, GLOB as TruncationGlob, outputPath } from "./truncation-dir"
 import { Context, Effect, Layer } from "effect"
+import { AppRuntime } from "@/effect"
 
 export namespace Truncate {
   export const MAX_LINES = 2000
@@ -115,7 +116,7 @@ export namespace Truncate {
         Scheduler.register({
           id: "tool.truncation.cleanup",
           interval: HOUR_MS,
-          run: () => Effect.runPromise(cleanup()),
+          run: () => AppRuntime.runPromise(cleanup()),
           scope: "global",
           skipInitialRun: true,
         })

--- a/packages/nikcli/src/tool/write.ts
+++ b/packages/nikcli/src/tool/write.ts
@@ -56,7 +56,7 @@ export const WriteTool = Tool.define("write", {
     await Bus.publish(File.Event.Edited, {
       file: filepath,
     })
-    FileTime.read(ctx.sessionID, filepath)
+    await FileTime.read(ctx.sessionID, filepath)
 
     let output = "Wrote file successfully."
     const diagnostics = await runLSP(


### PR DESCRIPTION
## Summary

Full review of Effect TS usage and package-wide coherence in `packages/nikcli` (cli/tui, session, project, tool, provider, then server, bus, auth, config, delegation, loop, share, image, cli/run), the structural improvements that came out of it, and the first migration phase of the session v2 data model. Every finding was verified against the actual code before changing anything; false positives were left untouched.

### 1. `fix(effect)` — Effect TS misuse in the focus areas
- `getSmallModel` impossible nested condition (dead code) → ORed.
- Dead `try/catch` around `yield*` in `Effect.gen` (failures abandon the iterator, so catch/finally never run): tool truncation fallback, `Provider.refresh` cache clear.
- `FileTime.read` not awaited in read/write (edit awaits it) — raced the freshness assert.
- `session/mode.ts` memoized per-directory modes in one module-level value — first directory leaked to every instance; now keyed by directory.
- Unhandled-rejection sweep: InstanceBootstrap fire-and-forget inits, models.dev hourly refresh, task/advisor background chains, session auto-share, skill loads, upgrade check, TUI worker SSE loop (now reconnects instead of dying).
- Bare `Effect.runPromise` entries in session/* now go through the shared `AppRuntime` / `locallyInstance`.

### 2. `fix` — package-wide coherence pass
- `Bus.publish` made rejection-safe at the source (~40 fire-and-forget call sites).
- `share.ts` queue could be permanently poisoned by one failed upload (rejected promise chain skipped every later `.then`).
- `auth.json` writes now serialize on a file lock (concurrent set/remove could drop a freshly refreshed token); corrupted store logs instead of silently emptying.
- `image.ts`: `finally { decoded.free() }` never ran on failing `yield*` paths → WASM leak per oversized attachment; resize moved to a plain function with reliable finally.
- models.dev `get()` now checks `response.ok` and guards `JSON.parse` (proxy error pages crashed provider loading).
- SSE heartbeats, PTY resize, `LoopEngine.runOnce`, delegation timeout/waiters: terminal catches + `unref()` on the reconcile interval.
- Remaining bare runtime entries (mobile routes per-session helpers, config tui/paths) moved to `withInstance` / `runPromiseWithLayer` / `AppRuntime`.
- `cli/run` event processor rejection now flows into the command error path.

### 3. `refactor(effect)` — structured InstanceScope bridge, per-call runner onInterrupt
- `InstanceScope.with` now forks the bridged effect on the shared AppRuntime via `Effect.callback`: the inner fiber's full Exit (typed failures, defects, interruption) is replayed in the caller's fiber, interrupting the caller interrupts the inner fiber **and waits for its finalizers**, and the error channel is `E | Error` instead of `unknown`. The ALS hand-off stays — legacy code inside effect bodies still reads `Instance.*` from AsyncLocalStorage.
- `runner.ts` / `run-state.ts`: `onInterrupt` was per-call in the signature but first-caller-wins in behavior; now genuinely per-call with the creation-time handler as fallback. `Busy` mapping via `instanceof` instead of a structural `_tag` probe.
- New tests: typed-failure preservation across the bridge, interruption propagation with finalizer wait, legacy ALS reads, auth concurrent-write serialization.

### 4. `refactor(server)` — mobile routes split, release test aligned
- `server/routes/mobile.ts` (4.1k lines, 76 routes) split into `server/routes/mobile/` (helpers + 10 thematic modules), composed with `.route("", ...)`: route inventory verified byte-identical pre/post split; code moved verbatim.
- `test/release/automation.test.ts` asserted the old combined push; the release script intentionally moved to separate branch push (rebase-and-retry) + tag push — test now asserts the current invariants instead of failing every run.

### 5. `feat(session)` — v2 migrated to a live read model over the v1 engine (strangler, phase 1)
The v1 engine stays the only writer, so retry/abort/tool-state/snapshot/permission behavior is unchanged by construction:
- **`SessionProjector`** (new): subscribes to the v1 bus events and mirrors only in-flight assistant messages; memory is bounded (a message leaves the mirror on completion/removal/session deletion — storage takes over). Publishes entry-grade `session.v2.updated` events (message lifecycle, tool state transitions); text deltas stay on v1 events by design. Per-instance lifecycle via `Instance.state`, activated from `InstanceBootstrap` (lazy import — a static one closes an import cycle through session/prompt).
- **`SessionV2.entries()`**: storage authoritative for committed messages + projector's in-flight tail (the old in-memory-first read went stale).
- **`SessionV2.prompt()`**: now actually delegates to the v1 `SessionPrompt` engine (it previously appended to a private map without ever prompting).
- **Lossless v1→v2 conversion** (`SessionEntry.fromV1Part`): tool error states (previously dropped entirely), running/pending calls, attachments, v1 retry parts → `AssistantRetry`, terminal message errors → entry metadata. `ToolResultPart` gains an `error` flag.
- **`Stepper.stepWith`** cast raw v1 parts into v2 schemas (a tool part failed `.parse` at runtime) and appended a junk entry per part event; parts now convert properly and attach to the open assistant step.
- **`SessionEvent.create`** typing was `Omit` over the union (collapsed to common keys; only prompt-shaped events typechecked) and used the output type — now a distributive `Draft` over the schema input type.
- Tests: lossless conversion, live projector via real bus events, stepWith entry-grade flow (17 v2 tests).

**Next (separate step):** swap the engine — drive the Stepper natively from the agent loop and retire the projector. The read/write API surface consumers need is in place now.

## Verification
- `tsgo --noEmit` clean; oxlint: no new warnings.
- Full unit suite: 1671+ pass; the only failures (workspace warp, Experimental/Workspace HttpApi, repo clone, Worktree.list, one timing benchmark) reproduce identically on the base commit in this sandbox — env-dependent, confirmed twice on pristine HEAD worktrees.
- Mobile route inventory byte-identical before/after the split (76 routes).

https://claude.ai/code/session_01LP2LkuYbsqAR5ikEDHjeoQ