### PR TITLE
feat(session): v2 live tail reduced through the Stepper + v2 read API over HTTP

### DIFF
--- a/packages/nikcli/specs/effect/schema.md
+++ b/packages/nikcli/specs/effect/schema.md
@@ -438,3 +438,9 @@ piecewise.
 - Every migrated file should leave the generated SDK output (`packages/sdk/
 openapi.json` and `packages/sdk/js/src/v2/gen/types.gen.ts`) byte-identical
   unless the change is deliberately user-visible.
+- Session v2 (`src/session/v2/`) stays zod-first for now: its schemas
+  (`SessionEntry`, `SessionEvent`) feed `hono-openapi` resolvers directly
+  (`GET /session/:id/v2/{entries,state}`). Migrate them to Effect Schema +
+  the walker together with `session/message-v2.ts`, not before — the v2
+  parts embed `MessageV2.FilePart`/`APIError` and must convert in lockstep.
+  Status of the v2 read model itself: specs/v2/message-shape.md.

--- a/packages/nikcli/specs/v2/message-shape.md
+++ b/packages/nikcli/specs/v2/message-shape.md
@@ -134,3 +134,36 @@ const msg = {
 ```
 
 Tradeoff: stored messages get much smaller and cleaner, but replay now has to join messages with turn state and prompt hooks still need a way to pick which turn they belong to.
+
+## Implementation status (2026-06-10)
+
+The entry/event/stepper shape is implemented in `src/session/v2/` and live,
+migrated by strangler over the v1 engine:
+
+- `SessionEntry` (entry.ts) — entries plus AI-SDK-aligned parts. Every part
+  carries an optional `ref` (the originating v1 part id) so live reductions
+  upsert instead of appending duplicates.
+- `SessionEvent` (event.ts) — the event vocabulary (`prompt`, `synthetic`,
+  `step.started`, `step.ended`, `part.updated`, `part.removed`,
+  `retry.error`). `Draft` distributes over the union (`z.input`-based) so
+  `create()` accepts each member's own keys.
+- `Stepper` (stepper.ts) — the immer reducer. `stepWith` is idempotent for
+  live streams: `upsertPart` replaces by `ref` (and a tool-result replaces
+  its tool-call by `toolCallId`); the open step is found with `findLast`
+  because retry entries may sit after it.
+- `SessionProjector` (projector.ts) — translates the v1 bus events
+  (`message.updated`, `message.part.updated`, `message.part.removed`) into
+  `SessionEvent`s and reduces them through `Stepper.stepWith`, so the live
+  tail is produced by the same reducer a future native v2 engine will use.
+  Publishes `session.v2.updated` only on entry-grade changes. State is
+  per-instance (`Instance.state`) and dropped on completion/removal/delete.
+- `SessionV2` (index.ts) — public API. Reads: `entries()` = lossless
+  conversion of storage + live pending tail; `state()`/`pending()` =
+  projector snapshot. Writes (`create`, `prompt`) still delegate to the v1
+  Session/SessionPrompt services (v1 stays the only writer).
+- Server: `GET /session/:id/v2/entries` and `GET /session/:id/v2/state`
+  (server/routes/session.ts); `session.v2.updated` reaches clients through
+  the existing bus → SSE forwarding.
+
+Not done yet: native v2 write path (engine swap), persistence of v2 events.
+Tests: `test/session/v2-conversion.test.ts`, `test/session/v2-projector.test.ts`.

--- a/packages/nikcli/src/server/routes/session.ts
+++ b/packages/nikcli/src/server/routes/session.ts
@@ -4,6 +4,8 @@ import { describeRoute, validator, resolver } from "hono-openapi"
 import z from "zod"
 import { Session } from "../../session"
 import { MessageV2 } from "../../session/message-v2"
+import { SessionV2 } from "../../session/v2"
+import { SessionEntry } from "../../session/v2/entry"
 import { SessionPrompt } from "../../session/prompt"
 import { SessionContext } from "../../session/context-breakdown"
 import { SessionCompaction } from "../../session/compaction"
@@ -1196,6 +1198,83 @@ export const SessionRoutes = lazy(() =>
           messageID: params.messageID,
         })
         return c.json(message)
+      },
+    )
+    .get(
+      "/:sessionID/v2/entries",
+      describeRoute({
+        summary: "Get session v2 entries",
+        description:
+          "Retrieve the session as v2 entries: committed messages converted from storage plus the live in-flight assistant tail. Experimental — the v2 read model is documented in specs/v2/message-shape.md.",
+        operationId: "session.v2.entries",
+        responses: {
+          200: {
+            description: "List of v2 entries",
+            content: {
+              "application/json": {
+                schema: resolver(SessionEntry.Entry.array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await runSession(
+          Effect.gen(function* () {
+            const service = yield* Session.Service
+            yield* service.get(sessionID)
+          }),
+        )
+        return c.json(await SessionV2.entries(sessionID))
+      },
+    )
+    .get(
+      "/:sessionID/v2/state",
+      describeRoute({
+        summary: "Get live session v2 state",
+        description:
+          "Retrieve the live v2 state for a session: `pending` holds the in-flight assistant work reduced by the v2 stepper. Entry-grade changes are announced on the bus as `session.v2.updated`. Experimental.",
+        operationId: "session.v2.state",
+        responses: {
+          200: {
+            description: "Live v2 state",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    entries: SessionEntry.Entry.array(),
+                    pending: SessionEntry.Entry.array(),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await runSession(
+          Effect.gen(function* () {
+            const service = yield* Session.Service
+            yield* service.get(sessionID)
+          }),
+        )
+        return c.json(SessionV2.state(sessionID))
       },
     )
     .delete(

--- a/packages/nikcli/src/session/v2/entry.ts
+++ b/packages/nikcli/src/session/v2/entry.ts
@@ -21,6 +21,13 @@ export namespace SessionEntry {
   // ============================================================================
 
   /**
+   * Originating v1 part id. Set whenever a part is converted from a live v1
+   * part so repeated `part.updated` events upsert (replace) instead of
+   * appending duplicates.
+   */
+  const Ref = z.string().optional()
+
+  /**
    * Text part — maps directly to AI SDK's `type: "text"` part
    */
   export const TextPart = z.object({
@@ -28,6 +35,7 @@ export namespace SessionEntry {
     text: z.string(),
     ignored: z.boolean().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
+    ref: Ref,
   })
   export type TextPart = z.infer<typeof TextPart>
 
@@ -38,6 +46,7 @@ export namespace SessionEntry {
     type: z.literal("reasoning"),
     text: z.string(),
     metadata: z.record(z.string(), z.unknown()).optional(),
+    ref: Ref,
   })
   export type ReasoningPart = z.infer<typeof ReasoningPart>
 
@@ -50,6 +59,7 @@ export namespace SessionEntry {
     toolName: z.string(),
     args: z.record(z.string(), z.unknown()),
     argsText: z.string().optional(),
+    ref: Ref,
   })
   export type ToolCallPart = z.infer<typeof ToolCallPart>
 
@@ -66,6 +76,7 @@ export namespace SessionEntry {
     result: z.string(),
     error: z.boolean().optional(),
     attachments: MessageV2.FilePart.array().optional(),
+    ref: Ref,
   })
   export type ToolResultPart = z.infer<typeof ToolResultPart>
 
@@ -191,9 +202,9 @@ export namespace SessionEntry {
   ): TextPart | ReasoningPart | ToolCallPart | ToolResultPart | undefined {
     switch (part.type) {
       case "text":
-        return { type: "text", text: part.text, ignored: part.ignored }
+        return { type: "text", text: part.text, ignored: part.ignored, ref: part.id }
       case "reasoning":
-        return { type: "reasoning", text: part.text }
+        return { type: "reasoning", text: part.text, ref: part.id }
       case "tool":
         switch (part.state.status) {
           case "completed":
@@ -203,6 +214,7 @@ export namespace SessionEntry {
               toolName: part.tool,
               result: part.state.output,
               attachments: part.state.attachments,
+              ref: part.id,
             }
           case "error":
             return {
@@ -211,6 +223,7 @@ export namespace SessionEntry {
               toolName: part.tool,
               result: part.state.error,
               error: true,
+              ref: part.id,
             }
           case "pending":
           case "running":
@@ -219,6 +232,7 @@ export namespace SessionEntry {
               toolCallId: part.callID,
               toolName: part.tool,
               args: part.state.input,
+              ref: part.id,
             }
         }
         return undefined

--- a/packages/nikcli/src/session/v2/index.ts
+++ b/packages/nikcli/src/session/v2/index.ts
@@ -18,12 +18,12 @@ import { runPromiseWithLayer, withCurrentInstance } from "@/effect"
  *
  * - reads (`entries`, `state`, `pending`) are first-class: storage is
  *   authoritative for completed messages (converted losslessly via
- *   `toEntries`), and `SessionProjector` overlays the in-flight assistant
- *   work streamed by the v1 engine — see projector.ts
+ *   `toEntries`), and `SessionProjector` translates the v1 engine's live
+ *   bus events into `SessionEvent`s reduced through `Stepper.stepWith` —
+ *   the in-flight tail is already native v2 state, see projector.ts
  * - writes (`create`, `prompt`) delegate to the v1 Session/SessionPrompt
  *   services, so behavior (retry, abort, tool state machine, snapshots,
  *   permissions) is exactly the production engine's
- * - `Stepper` remains the reducer for the future native v2 engine
  *
  * Consumers can adopt the v2 API today without behavior change; swapping
  * the engine underneath is a later, isolated step.
@@ -123,7 +123,7 @@ export namespace SessionV2 {
   /**
    * Get v2 entries for a session.
    * Storage (v1) is the authoritative source for committed messages; the
-   * projector's in-flight assistant work is appended as the live tail.
+   * projector's in-flight assistant reduction is appended as the live tail.
    */
   export async function entries(sessionID: string): Promise<SessionEntry.Entry[]> {
     const messages = await runSession(
@@ -132,9 +132,7 @@ export namespace SessionV2 {
         return yield* session.messages({ sessionID })
       }),
     )
-    const committed = new Set(messages.map((message) => message.info.id))
-    const live = SessionProjector.inflight(sessionID).filter((message) => !committed.has(message.info.id))
-    return toEntries([...messages, ...live], sessionID)
+    return [...toEntries(messages, sessionID), ...SessionProjector.snapshot(sessionID).pending]
   }
 
   /**
@@ -164,13 +162,10 @@ export namespace SessionV2 {
 
   /**
    * Live state for a session: committed entries are not duplicated here —
-   * `pending` reflects the projector's in-flight assistant messages.
+   * `pending` is the Stepper reduction of the in-flight assistant work.
    */
   export function state(sessionID: string): Stepper.MemoryState {
-    return {
-      entries: [],
-      pending: toEntries(SessionProjector.inflight(sessionID), sessionID),
-    }
+    return SessionProjector.snapshot(sessionID)
   }
 
   /**

--- a/packages/nikcli/src/session/v2/projector.ts
+++ b/packages/nikcli/src/session/v2/projector.ts
@@ -5,26 +5,30 @@ import { Log } from "@/util/log"
 import z from "zod"
 import { Session } from "../index"
 import { MessageV2 } from "../message-v2"
+import { SessionEvent } from "./event"
+import { Stepper } from "./stepper"
 
 /**
  * SessionProjector — live v2 read model over the v1 session engine.
  *
  * The v1 engine (session/processor.ts) stays the only writer: it persists
  * messages and publishes `message.updated` / `message.part.updated` /
- * `message.part.removed` on the Bus. This projector subscribes to those
- * events and mirrors ONLY the in-flight (not yet completed) assistant
- * messages, so `SessionV2.state()` can expose live pending entries without
- * touching the engine — migration by strangler, no behavior change in v1.
+ * `message.part.removed` on the Bus. This projector translates those events
+ * into the v2 `SessionEvent` vocabulary and reduces them through
+ * `Stepper.stepWith`, so the live tail a consumer reads from `snapshot()` is
+ * produced by the exact reducer the future native v2 engine will use —
+ * migration by strangler, no behavior change in v1.
  *
- * Memory is bounded by construction: a message is dropped from the mirror
- * the moment v1 marks it completed (it is then readable from storage via
+ * Memory is bounded by construction: only the single in-flight assistant
+ * message per session is reduced, and its state is dropped the moment v1
+ * marks it completed (it is then readable from storage via
  * `SessionV2.entries()`), when it is removed, or when its session is
  * deleted/disposed.
  *
  * Consumers that need character-level deltas keep using the v1
  * `message.part.updated` events; `session.v2.updated` fires only on
- * entry-grade changes (message lifecycle, tool state transitions, part
- * removal) to stay quiet during text streaming.
+ * entry-grade changes (message lifecycle, tool state transitions, retries,
+ * part removal) to stay quiet during text streaming.
  */
 export namespace SessionProjector {
   const log = Log.create({ service: "session.v2.projector" })
@@ -38,73 +42,123 @@ export namespace SessionProjector {
     ),
   }
 
-  interface Mirror {
-    info: MessageV2.Assistant
-    parts: Map<string, MessageV2.Part>
+  interface Live {
+    state: Stepper.MemoryState
+    /** messageID of the in-flight assistant message being reduced */
+    inflight?: string
+    /** partID → last entry-grade signature, to publish only on grade changes */
+    seen: Map<string, string>
   }
 
   interface State {
-    /** messageID → in-flight assistant message mirror */
-    inflight: Map<string, Mirror>
-    /** sessionID → in-flight messageIDs, for session-level lookup/cleanup */
-    bySession: Map<string, Set<string>>
+    /** sessionID → live reduction */
+    sessions: Map<string, Live>
     unsubscribes: (() => void)[]
   }
+
+  const empty = (): Stepper.MemoryState => ({ entries: [], pending: [] })
+
+  // stepWith's adapter is not consulted on the in-memory reduction path; a
+  // single shared no-op instance keeps the call sites honest.
+  const memoryAdapter = Stepper.memory().adapter
 
   const state = Instance.state<State>(
     () => {
       const s: State = {
-        inflight: new Map(),
-        bySession: new Map(),
+        sessions: new Map(),
         unsubscribes: [],
       }
 
-      const track = (info: MessageV2.Info) => {
-        if (info.role !== "assistant") return
-        if (info.time.completed) {
-          drop(s, info.id, info.sessionID)
-          publish(info.sessionID)
-          return
+      const live = (sessionID: string): Live => {
+        let target = s.sessions.get(sessionID)
+        if (!target) {
+          target = { state: empty(), seen: new Map() }
+          s.sessions.set(sessionID, target)
         }
-        const existing = s.inflight.get(info.id)
-        if (existing) {
-          existing.info = info
-          return
-        }
-        s.inflight.set(info.id, { info, parts: new Map() })
-        let ids = s.bySession.get(info.sessionID)
-        if (!ids) {
-          ids = new Set()
-          s.bySession.set(info.sessionID, ids)
-        }
-        ids.add(info.id)
-        publish(info.sessionID)
+        return target
+      }
+
+      const step = (target: Live, sessionID: string, draft: SessionEvent.Draft) => {
+        target.state = Stepper.stepWith(target.state, memoryAdapter, sessionID, SessionEvent.create(draft))
+      }
+
+      const drop = (target: Live) => {
+        target.state = empty()
+        target.inflight = undefined
+        target.seen.clear()
       }
 
       s.unsubscribes.push(
         Bus.subscribe(MessageV2.Event.Updated, (event) => {
-          track(event.properties.info)
+          const info = event.properties.info
+          if (info.role !== "assistant") return
+          const target = live(info.sessionID)
+          if (info.time.completed) {
+            if (target.inflight !== info.id) return
+            // storage is authoritative from here on: drop the live tail
+            drop(target)
+            publish(info.sessionID)
+            return
+          }
+          if (target.inflight === info.id) return
+          // a new assistant message went in flight: restart the reduction
+          drop(target)
+          target.inflight = info.id
+          step(target, info.sessionID, {
+            type: "step.started",
+            sessionID: info.sessionID,
+            messageID: info.id,
+            providerID: info.providerID,
+            modelID: info.modelID,
+            agent: info.agent,
+          })
+          publish(info.sessionID)
         }),
         Bus.subscribe(MessageV2.Event.PartUpdated, (event) => {
           const part = event.properties.part
-          const mirror = s.inflight.get(part.messageID)
-          if (!mirror) return
-          const previous = mirror.parts.get(part.id)
-          mirror.parts.set(part.id, part)
-          if (entryGradeChange(previous, part)) publish(part.sessionID)
+          const target = s.sessions.get(part.sessionID)
+          if (!target || target.inflight !== part.messageID) return
+          if (part.type === "retry") {
+            // retries are terminal per attempt — translate once
+            if (target.seen.has(part.id)) return
+            target.seen.set(part.id, "retry")
+            step(target, part.sessionID, {
+              type: "retry.error",
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              attempt: part.attempt,
+              error: part.error,
+            })
+            publish(part.sessionID)
+            return
+          }
+          const grade = part.type === "tool" ? part.state.status : "·"
+          const before = target.seen.get(part.id)
+          target.seen.set(part.id, grade)
+          step(target, part.sessionID, {
+            type: "part.updated",
+            sessionID: part.sessionID,
+            part,
+          })
+          if (before === undefined || before !== grade) publish(part.sessionID)
         }),
         Bus.subscribe(MessageV2.Event.PartRemoved, (event) => {
-          const mirror = s.inflight.get(event.properties.messageID)
-          if (!mirror) return
-          mirror.parts.delete(event.properties.partID)
-          publish(event.properties.sessionID)
+          const { sessionID, messageID, partID } = event.properties
+          const target = s.sessions.get(sessionID)
+          if (!target || target.inflight !== messageID) return
+          target.seen.delete(partID)
+          step(target, sessionID, { type: "part.removed", sessionID, messageID, partID })
+          publish(sessionID)
         }),
         Bus.subscribe(MessageV2.Event.Removed, (event) => {
-          drop(s, event.properties.messageID, event.properties.sessionID)
-          publish(event.properties.sessionID)
+          const { sessionID, messageID } = event.properties
+          const target = s.sessions.get(sessionID)
+          if (!target || target.inflight !== messageID) return
+          drop(target)
+          publish(sessionID)
         }),
         Bus.subscribe(Session.Event.Deleted, (event) => {
-          clearSession(s, event.properties.info.id)
+          s.sessions.delete(event.properties.info.id)
         }),
       )
 
@@ -113,63 +167,26 @@ export namespace SessionProjector {
     },
     async (s) => {
       for (const unsubscribe of s.unsubscribes) unsubscribe()
-      s.inflight.clear()
-      s.bySession.clear()
+      s.sessions.clear()
     },
   )
-
-  function drop(s: State, messageID: string, sessionID: string) {
-    s.inflight.delete(messageID)
-    const ids = s.bySession.get(sessionID)
-    if (!ids) return
-    ids.delete(messageID)
-    if (ids.size === 0) s.bySession.delete(sessionID)
-  }
-
-  function clearSession(s: State, sessionID: string) {
-    const ids = s.bySession.get(sessionID)
-    if (!ids) return
-    for (const id of ids) s.inflight.delete(id)
-    s.bySession.delete(sessionID)
-  }
-
-  /** Tool state transitions and structural parts matter; raw text/reasoning deltas do not. */
-  function entryGradeChange(previous: MessageV2.Part | undefined, next: MessageV2.Part): boolean {
-    if (next.type === "text" || next.type === "reasoning") return previous === undefined
-    if (next.type === "tool") {
-      return previous?.type !== "tool" || previous.state.status !== next.state.status
-    }
-    return true
-  }
-
-  function publish(sessionID: string) {
-    void Bus.publish(Event.Updated, { sessionID })
-  }
 
   /** Initialize (idempotent — first call per instance subscribes). */
   export function init() {
     state()
   }
 
-  /** In-flight assistant messages for a session, parts ordered by ascending id. */
-  export function inflight(sessionID: string): MessageV2.WithParts[] {
-    const s = state()
-    const ids = s.bySession.get(sessionID)
-    if (!ids) return []
-    const result: MessageV2.WithParts[] = []
-    for (const id of [...ids].sort()) {
-      const mirror = s.inflight.get(id)
-      if (!mirror) continue
-      result.push({
-        info: mirror.info,
-        parts: [...mirror.parts.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
-      })
-    }
-    return result
+  /** Live v2 state for a session — `pending` is the in-flight assistant tail. */
+  export function snapshot(sessionID: string): Stepper.MemoryState {
+    return state().sessions.get(sessionID)?.state ?? empty()
   }
 
   /** Drop all live state for a session. */
   export function clear(sessionID: string) {
-    clearSession(state(), sessionID)
+    state().sessions.delete(sessionID)
+  }
+
+  function publish(sessionID: string) {
+    void Bus.publish(Event.Updated, { sessionID })
   }
 }

--- a/packages/nikcli/src/session/v2/stepper.ts
+++ b/packages/nikcli/src/session/v2/stepper.ts
@@ -50,7 +50,8 @@ export namespace Stepper {
   export type Action =
     | { type: "append"; entry: SessionEntry.Entry }
     | { type: "appendPending"; entry: SessionEntry.Entry }
-    | { type: "appendPart"; part: SessionEntry.AssistantText["parts"][number] }
+    | { type: "upsertPart"; part: SessionEntry.AssistantText["parts"][number] }
+    | { type: "removePart"; ref: string }
     | { type: "removeLastPending" }
     | { type: "replacePending"; entries: SessionEntry.Entry[] }
     | { type: "finish"; result: StepResult }
@@ -101,6 +102,11 @@ export namespace Stepper {
   // Reducer
   // ============================================================================
 
+  /** The open step: a pending assistant-text entry that parts attach to. */
+  function isOpenStep(entry: SessionEntry.Entry): entry is SessionEntry.AssistantText {
+    return entry.role === "assistant" && entry.sub === "text"
+  }
+
   /**
    * Produce the next state based on an action (immer producer)
    */
@@ -115,13 +121,30 @@ export namespace Stepper {
           draft.pending.push(action.entry)
           break
         }
-        case "appendPart": {
-          // Attach a finalized part to the current (last pending) assistant
-          // step; without an open step there is nowhere coherent to put it.
-          const last = draft.pending.at(-1)
-          if (last && last.role === "assistant" && "parts" in last && last.sub === "text") {
-            last.parts.push(action.part)
-          }
+        case "upsertPart": {
+          // Attach a part to the open (last pending assistant-text) step —
+          // `findLast` because a retry entry may sit after the open step.
+          // Idempotent: a part with the same originating v1 part (`ref`)
+          // replaces in place, and a tool-result replaces its tool-call
+          // (same toolCallId). Without an open step there is nowhere
+          // coherent to put it.
+          const open = draft.pending.findLast(isOpenStep)
+          if (!open) break
+          const part = action.part
+          const index = open.parts.findIndex(
+            (existing) =>
+              (part.ref !== undefined && existing.ref === part.ref) ||
+              (part.type === "tool-result" && existing.type === "tool-call" && existing.toolCallId === part.toolCallId),
+          )
+          if (index >= 0) open.parts[index] = part
+          else open.parts.push(part)
+          break
+        }
+        case "removePart": {
+          const open = draft.pending.findLast(isOpenStep)
+          if (!open) break
+          const index = open.parts.findIndex((existing) => existing.ref === action.ref)
+          if (index >= 0) open.parts.splice(index, 1)
           break
         }
         case "removeLastPending": {
@@ -201,14 +224,13 @@ export namespace Stepper {
       }
 
       case "part.updated": {
-        // Contract: the event stream is entry-grade — one part.updated per
-        // finalized part, between step.started and step.ended. The v1 part is
-        // converted to its v2 shape and attached to the open assistant step.
+        // The v1 part is converted to its v2 shape and upserted into the open
+        // assistant step: live streams re-emit the same part (same `ref`)
+        // many times, so the reduction must be idempotent, not append-only.
         const part = SessionEntry.fromV1Part(event.part)
         if (!part) return state
-        const open = state.pending.at(-1)
-        if (open && open.role === "assistant" && "parts" in open && open.sub === "text") {
-          return reduce(state, { type: "appendPart", part })
+        if (state.pending.some(isOpenStep)) {
+          return reduce(state, { type: "upsertPart", part })
         }
         const entry = SessionEntry.AssistantText.parse({
           id: Identifier.ascending("event"),
@@ -225,7 +247,7 @@ export namespace Stepper {
       }
 
       case "part.removed": {
-        return reduce(state, { type: "removeLastPending" })
+        return reduce(state, { type: "removePart", ref: event.partID })
       }
 
       case "retry.error": {

--- a/packages/nikcli/test/session/v2-conversion.test.ts
+++ b/packages/nikcli/test/session/v2-conversion.test.ts
@@ -124,7 +124,11 @@ describe("SessionV2.toEntries", () => {
     expect(retry.sub).toBe("retry")
     expect(retry.attempt).toBe(2)
     expect(retry.error.data.message).toBe("rate limited")
-    expect((entries[1] as SessionEntry.AssistantText).parts[0]).toEqual({ type: "text", text: "recovered" })
+    expect((entries[1] as SessionEntry.AssistantText).parts[0]).toEqual({
+      type: "text",
+      text: "recovered",
+      ref: expect.any(String),
+    })
   })
 
   it("keeps terminal message errors instead of dropping the message", () => {

--- a/packages/nikcli/test/session/v2-projector.test.ts
+++ b/packages/nikcli/test/session/v2-projector.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, it } from "bun:test"
 import type { MessageV2 as MessageV2Types } from "@/session/message-v2"
+import type { SessionEntry as SessionEntryTypes } from "@/session/v2/entry"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
@@ -84,20 +85,25 @@ describe("SessionProjector", () => {
           },
         })
 
-        const inflight = SessionProjector.inflight(sessionID)
-        expect(inflight).toHaveLength(1)
-        expect(inflight[0].parts.map((p) => p.type)).toEqual(["text", "tool"])
-
-        // live state surfaces the in-flight work as pending v2 entries
+        // live state is the Stepper reduction of the in-flight work: one open
+        // assistant step carrying the real model and the converted parts
         const live = SessionV2.state(sessionID)
         expect(live.pending).toHaveLength(1)
-        expect(live.pending[0].role).toBe("assistant")
+        const open = live.pending[0] as SessionEntryTypes.AssistantText
+        expect(open.role).toBe("assistant")
+        expect(open.modelID).toBe("test-model")
+        expect(open.parts.map((p) => p.type)).toEqual(["text", "tool-result"])
 
-        // completion drops the mirror (storage becomes the source of truth)
+        // re-emitting the same part (streaming) must not duplicate it
+        await Bus.publish(MessageV2.Event.PartUpdated, { part: { ...textPart, text: "partial answer, longer" } })
+        const replayed = SessionV2.state(sessionID).pending[0] as SessionEntryTypes.AssistantText
+        expect(replayed.parts).toHaveLength(2)
+        expect(replayed.parts[0]).toMatchObject({ type: "text", text: "partial answer, longer" })
+
+        // completion drops the live tail (storage becomes the source of truth)
         await Bus.publish(MessageV2.Event.Updated, {
           info: assistantInfo(sessionID, { id: info.id, time: { created: info.time.created, completed: Date.now() } }),
         })
-        expect(SessionProjector.inflight(sessionID)).toHaveLength(0)
         expect(SessionV2.state(sessionID).pending).toHaveLength(0)
 
         // entry-grade updates were published (message created, tool transition,
@@ -125,14 +131,14 @@ describe("SessionProjector", () => {
             text: "orphan",
           },
         })
-        expect(SessionProjector.inflight(sessionID)).toHaveLength(0)
+        expect(SessionV2.state(sessionID).pending).toHaveLength(0)
 
         const info = assistantInfo(sessionID)
         await Bus.publish(MessageV2.Event.Updated, { info })
-        expect(SessionProjector.inflight(sessionID)).toHaveLength(1)
+        expect(SessionV2.state(sessionID).pending).toHaveLength(1)
 
         SessionV2.clear(sessionID)
-        expect(SessionProjector.inflight(sessionID)).toHaveLength(0)
+        expect(SessionV2.state(sessionID).pending).toHaveLength(0)
       },
     })
   })


### PR DESCRIPTION
## Summary

Phase 2 of the v1→v2 session strangler migration (follow-up to #97). The v1 engine stays the only writer; what changes is how the live in-flight tail is produced and where v2 can be consumed.

### Stepper as the live reducer
- `SessionEntry` parts now carry an optional `ref` — the originating v1 part id — and `SessionEntry.fromV1Part` stamps it on every conversion.
- `Stepper`: `appendPart` → **`upsertPart`** (idempotent: same `ref` replaces in place; a `tool-result` replaces its `tool-call` by `toolCallId`; the open step is found with `findLast` so a retry entry sitting after it doesn't break targeting) plus **`removePart(ref)`**. `part.removed` now removes the single part instead of popping the whole pending entry.
- Live streams re-emit the same part many times; the reduction is now safe under that, which is what allows the next change.

### Projector as a translator
`SessionProjector` no longer mirrors v1 shapes. It translates the v1 bus events (`message.updated`, `message.part.updated`, `message.part.removed`, `message.removed`, `session.deleted`) into v2 `SessionEvent`s and reduces them through `Stepper.stepWith` — so the live tail returned by `SessionV2.state()` is produced by the exact reducer a future native v2 engine will use. `session.v2.updated` still fires only on entry-grade changes (lifecycle, tool transitions, retries, removals), staying quiet during text streaming. State is per-instance and dropped on completion/removal/session delete.

### v2 read API over the server
- `GET /session/:id/v2/entries` — lossless conversion of committed storage + the live pending tail
- `GET /session/:id/v2/state` — the live stepper state (`pending` = in-flight assistant work)
- `session.v2.updated` already reaches clients through the existing bus → SSE forwarding.
- SDK gen files untouched (they regenerate at release time).

### Specs
Implementation-status section in `specs/v2/message-shape.md`; session-v2 schema-migration note in `specs/effect/schema.md`.

## Test plan
- `bun test test/session` — 502 pass, 0 fail (v2 suites reworked: idempotent re-emission, live state via `SessionV2.state`, orphan parts ignored, completion drops the tail)
- `bun test test/server/httpapi-session.test.ts` — pass
- `bun run typecheck` — clean (only pre-existing errors in unrelated local WIP files outside this PR)
- oxlint on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)