### PR TITLE
feat(session)!: remove the dedicated session.init route per the v2 plan

### DIFF
--- a/packages/nikcli/src/server/routes/session.ts
+++ b/packages/nikcli/src/server/routes/session.ts
@@ -631,62 +631,6 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .post(
-      "/:sessionID/init",
-      describeRoute({
-        summary: "Initialize session",
-        description:
-          "Analyze the current application and create an AGENTS.md file with project-specific agent configurations.",
-        operationId: "session.init",
-        responses: {
-          200: {
-            description: "200",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator(
-        "param",
-        z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
-        }),
-      ),
-      validator("json", Session.InitializeInput.omit({ sessionID: true })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        // Verify session exists first
-        await runSession(
-          Effect.gen(function* () {
-            const service = yield* Session.Service
-            yield* service.get(sessionID)
-          }),
-        )
-        // Then get instruction paths using current instance context
-        const ctx = captureInstanceContext()
-        const config = await runPromiseWithLayer(
-          Config.defaultLayer,
-          locallyInstance(
-            ctx,
-            Effect.gen(function* () {
-              const config = yield* Config.Service
-              return yield* config.get()
-            }),
-          ),
-        )
-        const { collectSystemPaths } = await import("../../session/instruction")
-        const result = await collectSystemPaths(ctx, config)
-        const instructions = Array.from(result.paths).map((p) => ({
-          path: p,
-          name: p.split("/").pop() || p,
-        }))
-        return c.json(instructions)
-      },
-    )
-    .post(
       "/:sessionID/fork",
       describeRoute({
         summary: "Fork session",

--- a/packages/nikcli/src/session/index.ts
+++ b/packages/nikcli/src/session/index.ts
@@ -15,9 +15,7 @@ import { Installation } from "../installation"
 import { Storage } from "../storage/storage"
 import { Log } from "../util/log"
 import { MessageV2 } from "./message-v2"
-import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
-import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
 
 import type { Provider } from "@/provider/provider"
@@ -45,13 +43,6 @@ function configGet(ctx?: InstanceContext) {
     return yield* config.get()
   })
   return runPromiseWithLayer(Config.defaultLayer, ctx ? locallyInstance(ctx, effect) : withCurrentInstance(effect))
-}
-
-function runSessionPrompt<A, E>(effect: Effect.Effect<A, E, SessionPrompt.Service>, ctx?: InstanceContext) {
-  return runPromiseWithLayer(
-    SessionPrompt.defaultLayer,
-    ctx ? locallyInstance(ctx, effect) : withCurrentInstance(effect),
-  )
 }
 
 function publishBus(ctx: InstanceContext, def: any, properties: any) {
@@ -321,14 +312,6 @@ export namespace Session {
     metadata: z.custom<ProviderMetadata>().optional(),
   })
   type UsageInput = z.infer<typeof UsageInput>
-
-  export const InitializeInput = z.object({
-    sessionID: ID,
-    modelID: z.string(),
-    providerID: z.string(),
-    messageID: Identifier.schema("message"),
-  })
-  export type InitializeInput = z.infer<typeof InitializeInput>
 
   export const Event = {
     Created: BusEvent.define(
@@ -892,22 +875,6 @@ export namespace Session {
    */
   export type Error = BusyError | Storage.NotFoundError | Storage.IOError
 
-  async function initializeImpl(ctx: InstanceContext, input: InitializeInput) {
-    await runSessionPrompt(
-      Effect.gen(function* () {
-        const sessionPrompt = yield* SessionPrompt.Service
-        yield* sessionPrompt.command({
-          sessionID: input.sessionID,
-          messageID: input.messageID,
-          model: input.providerID + "/" + input.modelID,
-          command: Command.Default.INIT,
-          arguments: "",
-        })
-      }),
-      ctx,
-    )
-  }
-
   export interface Interface {
     create(input?: CreateInput): Effect.Effect<Info, Error>
     fork(input: ForkInput): Effect.Effect<Info, Error>
@@ -931,7 +898,6 @@ export namespace Session {
     removePart(input: RemovePartInput): Effect.Effect<string, Error>
     updatePart(input: z.input<typeof UpdatePartInput>): Effect.Effect<MessageV2.Part, Error>
     getUsage(input: UsageInput): Effect.Effect<ReturnType<typeof getUsage>, never>
-    initialize(input: InitializeInput): Effect.Effect<void, Error>
   }
 
   export class Service extends Context.Service<Service, Interface>()("Session.Service") {}
@@ -1132,15 +1098,6 @@ export namespace Session {
           ),
         ),
       getUsage: (input) => Effect.sync(() => getUsage(input)),
-      initialize: (input) =>
-        InstanceState.context.pipe(
-          Effect.flatMap((ctx) =>
-            Effect.tryPromise({
-              try: () => initializeImpl(ctx, input),
-              catch: asSessionError,
-            }),
-          ),
-        ),
     }),
   )
 

--- a/specs/v2/session.md
+++ b/specs/v2/session.md
@@ -15,3 +15,12 @@ V2 plan:
 - remove the dedicated `session.init` endpoint
 - rely on the normal `/init` command flow instead
 - avoid reintroducing `Session.initialize`-style special cases in the session service layer
+
+Status: **done** (2026-06-10). The route, `Session.InitializeInput`,
+`Session.Service.initialize` and its `initializeImpl`/`runSessionPrompt`
+plumbing were removed — the handler had drifted anyway (it declared a
+boolean response but returned instruction paths, and ignored its validated
+body). The `/init` command flow (`Command.Default.INIT` via the command
+route) is the only path. Removing the `session/index.ts → session/prompt.ts`
+import also breaks that static cycle. SDK `session.init` disappears at the
+next release-time regeneration.


### PR DESCRIPTION
## Summary

Implements the spec'd v2 cleanup in `specs/v2/session.md`: the dedicated `POST /session/:sessionID/init` endpoint existed only as a compatibility wrapper around the normal `/init` command flow — and its handler had drifted: it declared a `boolean` response schema but returned instruction paths, and validated a body it never used. It has no in-repo callers.

- removes the route (`operationId: session.init`)
- removes `Session.InitializeInput`, `Session.Service.initialize`, `initializeImpl` and the `runSessionPrompt` helper (per the spec: no `Session.initialize`-style special cases in the service layer)
- as a side effect, drops the `session/index.ts → session/prompt.ts` static import cycle
- the generated SDK loses `session.init` at the next release-time regeneration
- spec marked done with a status note

The `/init` command flow (`Command.Default.INIT` via the command route) is untouched and remains the only path.

> Note for the merge: this same patch already exists on local `live-main` as `c79a7ad80`; merging this PR and pulling will resolve trivially (identical content).

## Test plan
- `bun run typecheck` — clean
- `bun test test/server/httpapi-session.test.ts test/server/httpapi-top-level.test.ts test/server/httpapi-public.test.ts test/session/v2-projector.test.ts` — 5 pass, 0 fail
- no references to `session.init`/`InitializeInput` remain outside release-time gen files

🤖 Generated with [Claude Code](https://claude.com/claude-code)