### PR TITLE
fix(test): seed httpapi-session bridge test through MessageRepo

### DIFF
--- a/packages/nikcli/test/server/httpapi-session.test.ts
+++ b/packages/nikcli/test/server/httpapi-session.test.ts
@@ -15,9 +15,7 @@ process.env.XDG_STATE_HOME = path.join(testHome, "state")
 const { Instance } = await import("@/project/instance")
 const { HttpApiBridge } = await import("@/server/httpapi/bridge")
 const { Server } = await import("@/server/server")
-const { Storage } = await import("@/storage/storage")
-const { runPromiseWithLayer } = await import("@/effect")
-const { Effect } = await import("effect")
+const { MessageRepo } = await import("@/session/message-repo")
 
 const projectDirs: string[] = []
 
@@ -71,16 +69,6 @@ async function jsonRequest(method: string, pathname: string, directory: string, 
     throw new Error(`Expected ${method} ${pathname} to return 200, got ${response.status}: ${await response.text()}`)
   }
   return response.json()
-}
-
-async function writeStorage(key: string[], value: unknown) {
-  await runPromiseWithLayer(
-    Storage.defaultLayer,
-    Effect.gen(function* () {
-      const storage = yield* Storage.Service
-      yield* storage.write(key, value)
-    }),
-  )
 }
 
 describe("Session HttpApi bridge", () => {
@@ -165,8 +153,10 @@ describe("Session HttpApi bridge", () => {
       type: "text",
       text: "hello",
     }
-    await writeStorage(["message", created.id, messageID], message)
-    await writeStorage(["part", messageID, partID], part)
+    // Messages and parts are read through the SQL repositories since the
+    // Drizzle adoption; seed them the same way the runtime writes them.
+    MessageRepo.upsertMessage(message as Parameters<typeof MessageRepo.upsertMessage>[0])
+    MessageRepo.upsertPart(part as Parameters<typeof MessageRepo.upsertPart>[0])
 
     const single = (await request(`/session/${created.id}/message/${messageID}`, directory)) as {
       info: { id: string }
@@ -205,7 +195,7 @@ describe("Session HttpApi bridge", () => {
     )) as boolean
     expect(removedPart).toBe(true)
 
-    await writeStorage(["part", messageID, partID], part)
+    MessageRepo.upsertPart(part as Parameters<typeof MessageRepo.upsertPart>[0])
     const removedMessage = (await remove(`/session/${created.id}/message/${messageID}`, directory)) as boolean
     expect(removedMessage).toBe(true)
 


### PR DESCRIPTION
## Summary

The full `packages/nikcli` suite has been failing 1 test since the SQL + Drizzle adoption (50b55f9a4): `Session HttpApi bridge > serves session list and status routes`.

The test still seeded its message/part fixture by writing JSON storage (`Storage.write(["message", …])`), but the routes now read through the SQL repositories — `GET /session/:id/message/:messageID` returned 500 (`Message not found`, thrown from `MessageV2.get`).

Seed the fixture through `MessageRepo.upsertMessage` / `upsertPart` (the same path the runtime writes) and drop the now-unused `writeStorage` helper and `Storage`/`Effect` imports.

This is also the failure behind the red `test`/`smoke` jobs visible on recent PRs.

## Test plan

- `bun test test/server/httpapi-session.test.ts` — 1 pass, 0 fail
- Full `bun test` in `packages/nikcli` — 1746 tests, 0 fail (was 1 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)