### PR TITLE
feat(tui): render image previews with native terminal protocols

### DIFF
--- a/packages/nikcli/src/cli/cmd/tui/component/tui-image.tsx
+++ b/packages/nikcli/src/cli/cmd/tui/component/tui-image.tsx
@@ -33,7 +33,7 @@ import { useTheme } from "@tui/context/theme"
  *
  * Terminals with iTerm2 or Sixel support receive a cursor-positioned overlay
  * during OpenTUI's native render pass. Every other terminal renders through
- * the grid with the colored Braille fallback.
+ * the grid with the truecolor ANSI half-block fallback.
  */
 const MAX_PREVIEW_BYTES = 10 * 1024 * 1024
 const MAX_PREVIEW_COLUMNS = 120
@@ -439,7 +439,7 @@ async function loadTuiImage(
     columns: bounds.columns,
     rows: bounds.rows,
     capabilities,
-    renderer: "braille",
+    renderer: "halfblock",
   })
   const fallback = result.output as string
   return {
@@ -449,7 +449,7 @@ async function loadTuiImage(
     height: 0,
     columns: result.columns,
     rows: toCellGrid(fallback, result.columns),
-    renderer: "braille",
+    renderer: "halfblock",
   }
 }
 
@@ -562,7 +562,7 @@ function TuiImage(props: { url: string; maxColumns: number; maxRows: number; wri
                   flexShrink={0}
                 />
               </Show>
-              <Show when={data().renderer === "braille" && data().rows.length > 0}>
+              <Show when={data().rows.length > 0}>
                 <box marginTop={1} flexDirection="column" flexShrink={0}>
                   <For each={data().rows}>
                     {(row) => (

--- a/packages/nikcli/src/cli/cmd/tui/component/tui-image.tsx
+++ b/packages/nikcli/src/cli/cmd/tui/component/tui-image.tsx
@@ -3,6 +3,7 @@ import { BoxRenderable, type CliRenderer, RGBA } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
 import {
   applyLiveCapabilities,
+  bestOverlayProtocol,
   detectCapabilities,
   encodeIterm2Bytes,
   encodeKittyVirtual,
@@ -30,10 +31,9 @@ import { useTheme } from "@tui/context/theme"
  * inside OpenTUI's grid. The terminal overlays the image wherever those
  * cells land, so scrolling and repaints just work.
  *
- * Every other terminal renders through the grid with the colored Braille
- * fallback. Raw protocol bytes are never written to stdout for display:
- * cursor-addressed output (classic kitty, iTerm2, Sixel) is clobbered by
- * the next OpenTUI frame and lands wherever the cursor happens to be.
+ * Terminals with iTerm2 or Sixel support receive a cursor-positioned overlay
+ * during OpenTUI's native render pass. Every other terminal renders through
+ * the grid with the colored Braille fallback.
  */
 const MAX_PREVIEW_BYTES = 10 * 1024 * 1024
 const MAX_PREVIEW_COLUMNS = 120
@@ -404,13 +404,14 @@ async function loadTuiImage(
     }
   }
 
-  if (capabilities.best === Protocol.ITERM2 || capabilities.best === Protocol.SIXEL) {
+  const overlayProtocol = bestOverlayProtocol(capabilities)
+  if (overlayProtocol) {
     const decoder = await pickDecoder()
     const image = await decoder(bytes)
     if (image.width <= 0 || image.height <= 0) throw new Error("decoder produced a zero-sized image")
     const { columns, rows } = fitNativeCells(image.width, image.height, bounds)
     const output =
-      capabilities.best === Protocol.ITERM2
+      overlayProtocol === Protocol.ITERM2
         ? encodeIterm2Bytes(bytes, {
             width: columns,
             height: rows,
@@ -425,7 +426,7 @@ async function loadTuiImage(
       columns,
       rows: [],
       overlay: { bytes: output, columns, rows },
-      renderer: capabilities.best === Protocol.ITERM2 ? "iterm2" : "sixel",
+      renderer: overlayProtocol === Protocol.ITERM2 ? "iterm2" : "sixel",
     }
   }
 

--- a/packages/tui-image/README.md
+++ b/packages/tui-image/README.md
@@ -42,6 +42,7 @@ the iTerm2 path, so images are rendered as pixels even when the shell is
 PowerShell.
 
 Terminals that expose none of these native protocols, including Windows
-Terminal, use the Braille or half-block renderer inside the OpenTUI grid.
-NikCLI's integration is in
+Terminal, use the truecolor ANSI half-block renderer inside the OpenTUI grid.
+The Braille renderer remains available when higher geometric resolution is
+more important than color fidelity. NikCLI's integration is in
 `packages/nikcli/src/cli/cmd/tui/component/tui-image.tsx`.

--- a/packages/tui-image/README.md
+++ b/packages/tui-image/README.md
@@ -1,0 +1,47 @@
+# @nikcli-ai/tui-image
+
+Terminal image rendering primitives for NikCLI and OpenTUI applications.
+
+The package decodes images into an RGBA pixel buffer and renders them with:
+
+- Kitty Graphics Protocol
+- Kitty Unicode placeholders for grid-safe OpenTUI placement
+- iTerm2 inline images
+- Sixel
+- Unicode half-block, Braille, and ASCII fallbacks
+
+## Render An Image
+
+```ts
+import { renderImage } from "@nikcli-ai/tui-image"
+
+const input = new Uint8Array(await Bun.file("logo.png").arrayBuffer())
+const result = await renderImage({
+  input,
+  columns: 60,
+  rows: 20,
+})
+
+process.stdout.write(typeof result.output === "string" ? result.output : Buffer.from(result.output))
+```
+
+`renderImage` uses conservative environment detection. OpenTUI consumers
+should merge `renderer.capabilities` with `applyLiveCapabilities` before
+selecting Kitty or Sixel.
+
+## OpenTUI Placement
+
+Cursor-addressed image protocols are not ordinary grid content. For Kitty and
+Ghostty, use `encodeKittyVirtual` and render the strings from
+`kittyPlaceholderGrid` as OpenTUI text cells using the foreground color from
+`kittyIdColor`.
+
+For terminals without Kitty Unicode placeholders, NikCLI can register an
+iTerm2 or Sixel cursor overlay in OpenTUI's native render pass. WezTerm uses
+the iTerm2 path, so images are rendered as pixels even when the shell is
+PowerShell.
+
+Terminals that expose none of these native protocols, including Windows
+Terminal, use the Braille or half-block renderer inside the OpenTUI grid.
+NikCLI's integration is in
+`packages/nikcli/src/cli/cmd/tui/component/tui-image.tsx`.

--- a/packages/tui-image/package.json
+++ b/packages/tui-image/package.json
@@ -5,11 +5,13 @@
   "private": true,
   "type": "module",
   "license": "MIT",
-  "description": "WASM-compatible image rendering for TUI / OpenTUI terminals — auto-detects Kitty Graphics, Sixel, iTerm2 and falls back to Unicode half-blocks. Single dependency-free public API; image decoding delegated to a host-supplied decoder (jimp, photon-node WASM, sharp, …) so the package works in Node, Bun and the browser.",
+  "description": "Image rendering primitives for TUI / OpenTUI terminals with Kitty, Sixel, iTerm2 and Unicode fallbacks.",
   "exports": {
     ".": "./src/index.ts",
     "./capabilities": "./src/capabilities.ts",
+    "./decode": "./src/decode.ts",
     "./encode": "./src/encode.ts",
+    "./kitty-placeholder": "./src/kitty-placeholder.ts",
     "./render": "./src/render.ts",
     "./pixels": "./src/pixels.ts"
   },

--- a/packages/tui-image/src/capabilities.ts
+++ b/packages/tui-image/src/capabilities.ts
@@ -6,8 +6,8 @@
  * the three modern graphics protocols the connected terminal advertises:
  *
  *  - {@link Protocol.KITTY}  — Kitty Graphics Protocol (Kitty, Ghostty, WezTerm ≥ 20230712, Konsole ≥ 22.04, Rio, Warp).
- *  - {@link Protocol.SIXEL}  — DEC Sixel (xterm, mlterm, WezTerm, Konsole, foot, Rio, VS Code ≥ 1.80, mintty).
- *  - {@link Protocol.ITERM2} — iTerm2 inline images (iTerm2 ≥ 2.9, WezTerm, Konsole, VS Code, mintty, Rio).
+ *  - {@link Protocol.SIXEL}  — DEC Sixel (mlterm, foot, Terminology, and terminals that report Sixel through OpenTUI).
+ *  - {@link Protocol.ITERM2} — iTerm2 inline images (iTerm2 ≥ 2.9, WezTerm, Konsole, mintty, Rio).
  *
  * Detection is *purely* synchronous and side-effect free; it never probes the
  * terminal by writing escape sequences. The OpenTUI `CliRenderer` already
@@ -58,6 +58,8 @@ export interface Capabilities {
   readonly terminal: string | null
 }
 
+export type OverlayProtocol = Protocol.SIXEL | Protocol.ITERM2
+
 interface Env {
   [key: string]: string | undefined
 }
@@ -87,13 +89,10 @@ export function protocolForTerminal(
   if (lower.includes("konsole")) return Protocol.KITTY // Konsole ≥ 22.04 supports Kitty
   if (lower.includes("rio")) return Protocol.KITTY
   if (lower.includes("iterm")) return Protocol.ITERM2
-  if (lower.includes("vscode")) return Protocol.ITERM2
+  if (lower.includes("vscode")) return null
   if (lower.includes("mintty")) return Protocol.ITERM2
-  if (lower.includes("alacritty")) return Protocol.SIXEL // alacritty has a Sixel shim
-  if (lower.includes("xterm")) return Protocol.SIXEL
   if (lower.includes("mlterm")) return Protocol.SIXEL
   if (lower.includes("foot")) return Protocol.SIXEL
-  if (lower.includes("screen")) return Protocol.SIXEL
   return null
 }
 
@@ -119,17 +118,13 @@ export interface LiveCapabilities {
  * Merge the env-based heuristic with the answer the terminal actually gave at
  * startup (surfaced by OpenTUI as `renderer.capabilities`).
  *
- * - Sixel: the DA1 response is authoritative in both directions. Nearly every
- *   terminal sets `TERM=xterm-256color`, so the env heuristic alone yields
- *   false positives — the sixel bytes are then swallowed silently and the
- *   preview renders as a blank box.
+ * - Sixel: the DA1 response is authoritative. Generic identifiers such as
+ *   `TERM=xterm-256color` are deliberately not treated as proof of support.
  * - Kitty: a negotiated `true` augments the env answer; a negotiated `false`
  *   keeps explicit env signals (`KITTY_WINDOW_ID`, …) intact, since the query
  *   can be lost behind multiplexers.
- * - iTerm2: not queryable. Explicit env signals (real iTerm2, WezTerm,
- *   mintty, …) are trusted; for xterm.js-based terminals (VS Code & friends,
- *   where images are an opt-in addon) support is only assumed when the addon
- *   advertises sixel in DA1.
+ * - iTerm2: not queryable through DA1. Only explicit terminal identifiers
+ *   (real iTerm2, WezTerm, mintty, …) are trusted.
  */
 export function applyLiveCapabilities(
   detected: Capabilities,
@@ -180,20 +175,25 @@ export function detectCapabilities(stream?: StreamProbe, env: Env = readEnv()): 
   for (const candidate of candidates) {
     const protocol = protocolForTerminal(candidate, colorterm)
     if (protocol) detected.add(protocol)
+    if (candidate.toLowerCase().includes("wezterm")) {
+      detected.add(Protocol.ITERM2)
+    }
   }
 
   // Kitty exposes a stable env var; honour it as an authoritative signal even
   // when the surrounding TERM is misleading.
   if (env.KITTY_WINDOW_ID || env.KITTY_PID || env.KITTY_PUBLIC_KEY) detected.add(Protocol.KITTY)
   if (env.GHOSTTY_RESOURCES_DIR || env.GHOSTTY_BIN_DIR) detected.add(Protocol.KITTY)
-  if (env.WEZTERM_EXECUTABLE || env.WEZTERM_PANE) detected.add(Protocol.KITTY)
+  if (env.WEZTERM_EXECUTABLE || env.WEZTERM_PANE) {
+    detected.add(Protocol.KITTY)
+    detected.add(Protocol.ITERM2)
+  }
   if (env.KONSOLE_VERSION) {
     const major = Number.parseInt(env.KONSOLE_VERSION.split(".")[0] ?? "0", 10)
     if (Number.isFinite(major) && major >= 22) detected.add(Protocol.KITTY)
     else detected.add(Protocol.SIXEL)
   }
   if (env.ITERM_SESSION_ID) detected.add(Protocol.ITERM2)
-  if (env.WT_SESSION) detected.add(Protocol.SIXEL) // Windows Terminal
   if (env.TERMINOLOGY_VERSION) detected.add(Protocol.SIXEL)
 
   // On stderr, several terminals disable sixel/iterm2 to keep logs readable.
@@ -211,4 +211,14 @@ export function detectCapabilities(stream?: StreamProbe, env: Env = readEnv()): 
     iterm2: detected.has(Protocol.ITERM2),
     terminal: termProgram ?? term,
   }
+}
+
+/**
+ * Pick a cursor-addressed protocol for renderers that cannot use Kitty
+ * Unicode placeholders. Sixel wins when both overlay protocols are available.
+ */
+export function bestOverlayProtocol(capabilities: Capabilities): OverlayProtocol | null {
+  if (capabilities.available.includes(Protocol.SIXEL)) return Protocol.SIXEL
+  if (capabilities.available.includes(Protocol.ITERM2)) return Protocol.ITERM2
+  return null
 }

--- a/packages/tui-image/src/encode.ts
+++ b/packages/tui-image/src/encode.ts
@@ -31,11 +31,6 @@ function apc(keys: string[], payload?: string): string {
   return payload === undefined ? `${ESC}_G${control}${ST}` : `${ESC}_G${control};${payload}${ST}`
 }
 
-/** iTerm2 inline images use a different framing: `OSC 1337 ; … ST`. */
-function osc(...parts: string[]): string {
-  return `${ESC}]1337;${parts.join(";")}${ST}`
-}
-
 function base64FromBytes(bytes: Uint8Array): string {
   if (typeof Buffer !== "undefined") {
     return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64")
@@ -283,10 +278,14 @@ export function encodeIterm2Bytes(image: Uint8Array, options: Iterm2Options = {}
   const width = options.width ?? "auto"
   const height = options.height ?? "auto"
   const preserve = options.preserveAspectRatio !== false ? "1" : "0"
-  return osc(
-    `file=${image.byteLength};width=${width};height=${height};preserveAspectRatio=${preserve};inline=1`,
-    payload,
-  )
+  const arguments_ = [
+    `size=${image.byteLength}`,
+    `width=${width}`,
+    `height=${height}`,
+    `preserveAspectRatio=${preserve}`,
+    "inline=1",
+  ].join(";")
+  return `${ESC}]1337;File=${arguments_}:${payload}${ST}`
 }
 
 /**
@@ -332,72 +331,81 @@ function nearestPaletteIndex(r: number, g: number, b: number): number {
  * Reference: <https://vt100.net/docs/vt3xx-gp/chapter14.html>
  */
 export function encodeSixel(image: PixelImage): Uint8Array {
-  // Initialise a 256-colour palette; we register only the colours we use.
-  const usedPalette = new Map<number, number>() // palette index → sixel register
-  let nextRegister = 0
+  const pixels = new Int16Array(image.width * image.height)
+  pixels.fill(-1)
+  const usedPalette = new Map<number, number>()
+
+  for (let y = 0; y < image.height; y++) {
+    for (let x = 0; x < image.width; x++) {
+      const offset = (y * image.width + x) * 4
+      const alpha = (image.data[offset + 3] ?? 0) / 255
+      if (alpha < 0.5) continue
+      const paletteIndex = nearestPaletteIndex(
+        (image.data[offset] ?? 0) * alpha,
+        (image.data[offset + 1] ?? 0) * alpha,
+        (image.data[offset + 2] ?? 0) * alpha,
+      )
+      let register = usedPalette.get(paletteIndex)
+      if (register === undefined) {
+        register = usedPalette.size
+        usedPalette.set(paletteIndex, register)
+      }
+      pixels[y * image.width + x] = register
+    }
+  }
+
   const parts: number[] = []
   const push = (s: string) => {
     for (let i = 0; i < s.length; i++) parts.push(s.charCodeAt(i) & 0x7f)
   }
+  const pushRun = (value: number, length: number) => {
+    const char = String.fromCharCode(0x3f + value)
+    push(length >= 4 ? `!${length}${char}` : char.repeat(length))
+  }
 
   push("\x1bPq") // DECSIXEL introducer
-  push('"1;1;0;0;0') // raster attributes: 1:1 pixel aspect, 0×0 image size hints
-  // We track the per-row run-length encoding state across columns.
-  let lastRegister = -1
+  push(`"1;1;${image.width};${image.height}`)
+  for (const [paletteIndex, register] of usedPalette) {
+    const [r, g, b] = SIXEL_PALETTE[paletteIndex]!
+    push(`#${register};2;${Math.round((r / 255) * 100)};${Math.round((g / 255) * 100)};${Math.round((b / 255) * 100)}`)
+  }
+
   for (let y = 0; y < image.height; y += 6) {
-    let runStart = 0
-    let runRegister = -1
-    let runChar = 0
-    const flushRun = (endX: number) => {
-      if (runRegister === -1 || endX <= runStart) return
-      const length = endX - runStart
-      if (length > 1) push(`!${length}`)
-      if (runRegister !== lastRegister) {
-        push(`#${runRegister}`)
-        lastRegister = runRegister
-      }
-      push(String.fromCharCode(0x3f + runChar))
-    }
+    const bandRegisters = new Set<number>()
     for (let x = 0; x < image.width; x++) {
-      let band = 0
       for (let dy = 0; dy < 6; dy++) {
         const yy = y + dy
         if (yy >= image.height) break
-        const i = (yy * image.width + x) * 4
-        const a = (image.data[i + 3] ?? 0) / 255
-        if (a < 0.5) continue
-        const r = (image.data[i] ?? 0) * a
-        const g = (image.data[i + 1] ?? 0) * a
-        const b = (image.data[i + 2] ?? 0) * a
-        const idx = nearestPaletteIndex(r, g, b)
-        const register = usedPalette.get(idx) ?? -1
-        if (register === -1 && nextRegister < 256) {
-          usedPalette.set(idx, nextRegister)
-          const entry = SIXEL_PALETTE[idx]!
-          push(`#${nextRegister};2;${Math.round(entry[0])};${Math.round(entry[1])};${Math.round(entry[2])}`)
-          runRegister = nextRegister
-          nextRegister += 1
-        } else {
-          runRegister = register
-        }
-        if (runRegister === -1) continue
-        band |= 1 << dy
+        const register = pixels[yy * image.width + x] ?? -1
+        if (register >= 0) bandRegisters.add(register)
       }
-      if (band === runChar && runRegister !== -1) continue
-      flushRun(x)
-      runStart = x
-      runChar = band
-      if (band === 0) {
-        runRegister = -1
-        continue
-      }
-      const idx = band >= 0x20 ? -1 : -1
-      if (idx === -1) runRegister = runRegister
     }
-    flushRun(image.width)
-    push("$") // carriage return (move to start of next band)
-    push("-") // line feed (advance to next sixel band)
-    lastRegister = -1
+
+    const registers = [...bandRegisters]
+    for (let registerIndex = 0; registerIndex < registers.length; registerIndex++) {
+      const register = registers[registerIndex]!
+      push(`#${register}`)
+      let runValue = -1
+      let runLength = 0
+      for (let x = 0; x < image.width; x++) {
+        let value = 0
+        for (let dy = 0; dy < 6; dy++) {
+          const yy = y + dy
+          if (yy >= image.height) break
+          if (pixels[yy * image.width + x] === register) value |= 1 << dy
+        }
+        if (value === runValue) {
+          runLength += 1
+          continue
+        }
+        if (runLength > 0) pushRun(runValue, runLength)
+        runValue = value
+        runLength = 1
+      }
+      if (runLength > 0) pushRun(runValue, runLength)
+      if (registerIndex < registers.length - 1) push("$")
+    }
+    if (y + 6 < image.height) push("-")
   }
   push("\x1b\\") // ST
   return new Uint8Array(parts)

--- a/packages/tui-image/test/capabilities.test.ts
+++ b/packages/tui-image/test/capabilities.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { applyLiveCapabilities, detectCapabilities, Protocol, protocolForTerminal } from "../src/capabilities"
+import {
+  applyLiveCapabilities,
+  bestOverlayProtocol,
+  detectCapabilities,
+  Protocol,
+  protocolForTerminal,
+} from "../src/capabilities"
 
 describe("protocolForTerminal", () => {
   test("recognises kitty", () => {
@@ -18,12 +24,12 @@ describe("protocolForTerminal", () => {
     expect(protocolForTerminal("iTerm.app", undefined)).toBe(Protocol.ITERM2)
   })
 
-  test("recognises vscode", () => {
-    expect(protocolForTerminal("vscode", undefined)).toBe(Protocol.ITERM2)
+  test("does not guess image support for vscode", () => {
+    expect(protocolForTerminal("vscode", undefined)).toBeNull()
   })
 
-  test("recognises xterm (sixel)", () => {
-    expect(protocolForTerminal("xterm-256color", undefined)).toBe(Protocol.SIXEL)
+  test("does not guess sixel for generic xterm", () => {
+    expect(protocolForTerminal("xterm-256color", undefined)).toBeNull()
   })
 
   test("returns null on unknown", () => {
@@ -51,9 +57,25 @@ describe("detectCapabilities", () => {
     expect(caps.iterm2).toBe(true)
   })
 
-  test("honours WT_SESSION as sixel", () => {
+  test("detects both Kitty and iTerm2 in WezTerm", () => {
+    const caps = detectCapabilities(undefined, { TERM_PROGRAM: "WezTerm" })
+    expect(caps.kitty).toBe(true)
+    expect(caps.iterm2).toBe(true)
+    expect(caps.best).toBe(Protocol.KITTY)
+    expect(caps.available).toContain(Protocol.ITERM2)
+  })
+
+  test("detects both protocols from WezTerm environment variables", () => {
+    const caps = detectCapabilities(undefined, {
+      WEZTERM_EXECUTABLE: "C:\\Program Files\\WezTerm\\wezterm-gui.exe",
+    })
+    expect(caps.kitty).toBe(true)
+    expect(caps.iterm2).toBe(true)
+  })
+
+  test("does not guess sixel from WT_SESSION", () => {
     const caps = detectCapabilities(undefined, { WT_SESSION: "abc" })
-    expect(caps.sixel).toBe(true)
+    expect(caps.sixel).toBe(false)
   })
 
   test("honours KONSOLE_VERSION >= 22 for kitty, < 22 for sixel", () => {
@@ -85,11 +107,11 @@ describe("applyLiveCapabilities", () => {
   test("passthrough when live answer is unavailable", () => {
     const detected = detectCapabilities(undefined, { TERM: "xterm-256color" })
     expect(applyLiveCapabilities(detected, null, {})).toBe(detected)
+    expect(detected.best).toBeNull()
   })
 
-  test("negotiated DA1 without sixel drops the TERM=xterm guess", () => {
+  test("negotiated DA1 without sixel keeps generic xterm disabled", () => {
     const detected = detectCapabilities(undefined, { TERM: "xterm-256color" })
-    expect(detected.best).toBe(Protocol.SIXEL)
     const merged = applyLiveCapabilities(detected, { sixel: false }, {})
     expect(merged.sixel).toBe(false)
     expect(merged.best).toBeNull()
@@ -101,20 +123,24 @@ describe("applyLiveCapabilities", () => {
     expect(merged.best).toBe(Protocol.SIXEL)
   })
 
-  test("vscode iterm2 guess requires the image addon (sixel in DA1)", () => {
+  test("vscode only enables the protocol negotiated by OpenTUI", () => {
     const env = { TERM: "xterm-256color", TERM_PROGRAM: "vscode" }
     const detected = detectCapabilities(undefined, env)
-    expect(detected.iterm2).toBe(true)
+    expect(detected.iterm2).toBe(false)
     const disabled = applyLiveCapabilities(detected, { sixel: false }, env)
     expect(disabled.iterm2).toBe(false)
     expect(disabled.best).toBeNull()
     const enabled = applyLiveCapabilities(detected, { sixel: true }, env)
-    expect(enabled.iterm2).toBe(true)
+    expect(enabled.iterm2).toBe(false)
     expect(enabled.best).toBe(Protocol.SIXEL)
   })
 
   test("real iTerm2 keeps iterm2 even without sixel in DA1", () => {
-    const env = { TERM: "xterm-256color", TERM_PROGRAM: "iTerm.app", ITERM_SESSION_ID: "abc" }
+    const env = {
+      TERM: "xterm-256color",
+      TERM_PROGRAM: "iTerm.app",
+      ITERM_SESSION_ID: "abc",
+    }
     const detected = detectCapabilities(undefined, env)
     const merged = applyLiveCapabilities(detected, { sixel: false }, env)
     expect(merged.iterm2).toBe(true)
@@ -133,5 +159,25 @@ describe("applyLiveCapabilities", () => {
     const detected = detectCapabilities(undefined, env)
     const merged = applyLiveCapabilities(detected, { kitty_graphics: false, sixel: false }, env)
     expect(merged.kitty).toBe(true)
+  })
+})
+
+describe("bestOverlayProtocol", () => {
+  test("uses iTerm2 when Kitty placeholders are unavailable", () => {
+    const caps = detectCapabilities(undefined, { TERM_PROGRAM: "WezTerm" })
+    expect(bestOverlayProtocol(caps)).toBe(Protocol.ITERM2)
+  })
+
+  test("prefers Sixel over iTerm2", () => {
+    const caps = detectCapabilities(undefined, {
+      TERM_PROGRAM: "WezTerm",
+      TERMINOLOGY_VERSION: "1",
+    })
+    expect(bestOverlayProtocol(caps)).toBe(Protocol.SIXEL)
+  })
+
+  test("returns null when only Kitty is available", () => {
+    const caps = detectCapabilities(undefined, { KITTY_WINDOW_ID: "1" })
+    expect(bestOverlayProtocol(caps)).toBeNull()
   })
 })

--- a/packages/tui-image/test/encode.test.ts
+++ b/packages/tui-image/test/encode.test.ts
@@ -34,16 +34,18 @@ describe("encodeIterm2", () => {
   test("emits an OSC 1337 file payload", () => {
     const image = checkeredImage(4, 4)
     const out = encodeIterm2(image, { width: 4, height: 4 })
-    expect(out.startsWith("\x1b]1337;")).toBe(true)
-    expect(out).toMatch(/file=\d+/)
+    expect(out.startsWith("\x1b]1337;File=")).toBe(true)
+    expect(out).toMatch(/File=size=\d+/)
     expect(out).toMatch(/inline=1/)
+    expect(out).toContain(":")
   })
 
   test("forwards compressed image bytes without re-encoding", () => {
     const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
     const out = encodeIterm2Bytes(bytes, { width: 20, height: 10 })
-    expect(out).toContain("file=4;width=20;height=10")
-    expect(out).toContain(Buffer.from(bytes).toString("base64"))
+    const payload = Buffer.from(bytes).toString("base64")
+    expect(out).toContain("File=size=4;width=20;height=10")
+    expect(out).toContain(`inline=1:${payload}`)
   })
 })
 
@@ -56,6 +58,16 @@ describe("encodeSixel", () => {
     expect(out[2]).toBe(0x71) // 'q'
     expect(out[out.length - 2]).toBe(0x1b)
     expect(out[out.length - 1]).toBe(0x5c)
+  })
+
+  test("encodes multiple colours as separate planes with 0..100 RGB values", () => {
+    const image = solidImage(1, 2, 255, 0, 0)
+    setPixel(image, 0, 1, [0, 0, 255, 255])
+    const out = Buffer.from(encodeSixel(image)).toString("ascii")
+    expect(out).toContain('"1;1;1;2')
+    expect(out).toMatch(/#0;2;100;0;0/)
+    expect(out).toMatch(/#1;2;0;0;100/)
+    expect(out).toContain("#0@$#1A")
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds reliable image previews to the OpenTUI prompt flow.

- Uses Kitty Unicode placeholders in Kitty and Ghostty so native images remain aligned with the OpenTUI grid.
- Uses cursor overlays for negotiated Sixel support and iTerm2 inline images.
- Detects WezTerm as both Kitty-capable and iTerm2-capable, then selects iTerm2 when Kitty placeholders are unavailable.
- Uses truecolor ANSI half-block cells in Windows Terminal and terminals without native image protocols; Braille remains available as an optional higher-detail renderer.
- Fixes the iTerm2 OSC 1337 `File=` payload and rewrites Sixel output as per-color planes with correct 0-100 RGB values.
- Removes unsafe protocol guesses for generic xterm, VS Code, Alacritty, screen, and `WT_SESSION`; live OpenTUI capability negotiation is used instead.
- Exposes the decoder and Kitty-placeholder package entry points and documents OpenTUI integration.

### How did you verify your code works?

- `bun test` in `packages/tui-image`: 66 passing tests.
- `bun run typecheck` in `packages/tui-image`.
- `bun run typecheck` in `packages/nikcli`.
- `git diff --check`.
- Manually verified from PowerShell inside WezTerm: pasted images render with the `iterm2` renderer instead of a cell fallback.

The repository-wide pre-push hook still fails on the unchanged `live-main` file `packages/app/src/custom-elements.d.ts`, which currently contains a bare relative path and produces TS1128. This PR does not modify that file.

### Screenshots / recordings

No recording attached. The native path was verified interactively in WezTerm on Windows with PowerShell.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR