### PR TITLE
Add non-null assertion to store.methodIndex in OAuth callback

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -339,7 +339,7 @@ export function DialogConnectProvider(props: { provider: string }) {
                       const result = await globalSDK.client.provider.oauth
                         .callback({
                           providerID: props.provider,
-                          method: store.methodIndex,
+                          method: store.methodIndex!,
                           code,
                         })
                         .then((value) =>
@@ -402,7 +402,7 @@ export function DialogConnectProvider(props: { provider: string }) {
                         const result = await globalSDK.client.provider.oauth
                           .callback({
                             providerID: props.provider,
-                            method: store.methodIndex,
+                            method: store.methodIndex!,
                           })
                           .then((value) =>
                             value.error ? { ok: false as const, error: value.error } : { ok: true as const },


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds non-null assertion operators (`!`) to `store.methodIndex` in two locations within the OAuth callback handler in `dialog-connect-provider.tsx`. 

The `methodIndex` property is guaranteed to be set before these callback handlers are invoked, but TypeScript's type checker cannot infer this guarantee from the control flow. Adding the non-null assertion operator tells TypeScript that we've verified `methodIndex` is not null/undefined at these points, resolving type safety issues without changing runtime behavior.

### How did you verify your code works?

TypeScript compilation passes with these changes. The assertions are safe because `methodIndex` is initialized before the OAuth flow begins and remains set throughout the callback execution.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

https://claude.ai/code/session_016gNBCXVSCg6B4hN16RJmAx