### PR TITLE
fix(desktop): use prebuilt CLI sidecar in CI + drop Apple signing

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -75,6 +75,7 @@ jobs:
     uses: ./.github/workflows/desktop-release.yml
     with:
       tag: ${{ needs.publish.outputs.tag }}
+      cli_run_id: ${{ needs.publish.outputs.run_id }}
     secrets: inherit
 
   railway-deploy:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -14,12 +14,22 @@ on:
         description: "Release tag to attach desktop artifacts to (e.g. v1.106.0)"
         required: true
         type: string
+      cli_run_id:
+        description: "GitHub Actions run ID of the publish job that produced the prebuilt `nikcli-cli` artifact (used by `bun run prepare:sidecar` to download the sidecar instead of rebuilding it)"
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag to attach desktop artifacts to (e.g. v1.106.0)"
         required: true
         type: string
+      cli_run_id:
+        description: "GitHub Actions run ID of the publish job that produced the prebuilt `nikcli-cli` artifact"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: desktop-release-${{ inputs.tag }}
@@ -86,6 +96,11 @@ jobs:
       # prepares the per-target nikcli sidecar and builds the frontend automatically.
       # When a signing key is present we use the prod config so Tauri also emits the
       # auto-updater artifacts (+ .sig); otherwise we ship installers only.
+      #
+      # Apple code signing is intentionally disabled — the published macOS bundles
+      # are unsigned. Users get a first-launch Gatekeeper prompt and can
+      # right-click → Open. We can revisit (notarization + Developer ID) once we
+      # have a stable keychain secret.
       - name: Build desktop app
         id: build
         working-directory: packages/desktop
@@ -93,12 +108,11 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          # `prepare:sidecar` (predev.ts) downloads the prebuilt CLI artifact
+          # when this is set, instead of rebuilding it locally. Rebuilding the
+          # CLI cross-platform on every desktop runner is fragile (Bin's bin
+          # remap step fails on Windows with `could not create process`).
+          CLI_ARTIFACT_RUN_ID: ${{ inputs.cli_run_id }}
         run: |
           set -euo pipefail
           CONFIG_ARG=""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ on:
       version:
         description: "Released version (e.g. 1.106.0)"
         value: ${{ jobs.publish.outputs.version }}
+      run_id:
+        description: "GitHub Actions run ID that produced the nikcli-cli artifact (downstream jobs use it to download the prebuilt CLI via `gh run download`)"
+        value: ${{ jobs.publish.outputs.run_id }}
   push:
     branches:
       - snapshot-*
@@ -121,6 +124,7 @@ jobs:
       release: ${{ steps.publish.outputs.release }}
       tag: ${{ steps.publish.outputs.tag }}
       version: ${{ steps.publish.outputs.version }}
+      run_id: ${{ github.run_id }}
 
   publish-release:
     needs:

--- a/packages/desktop/scripts/predev.ts
+++ b/packages/desktop/scripts/predev.ts
@@ -1,13 +1,50 @@
-import { $ } from "bun"
+#!/usr/bin/env bun
+import { $ } from "bun";
 
-import { copyBinaryToSidecarFolder, getCurrentSidecar, windowsify } from "./utils"
+import { Script } from "@nikcli-ai/script";
+import {
+  copyBinaryToSidecarFolder,
+  getCurrentSidecar,
+  windowsify,
+} from "./utils";
 
-const RUST_TARGET = Bun.env.TAURI_ENV_TARGET_TRIPLE
+// Sync the desktop package.json to the current CLI version so the sidecar
+// lookup matches what users have installed globally.
+const pkg = await Bun.file("./package.json").json();
+pkg.version = Script.version;
+await Bun.write("./package.json", JSON.stringify(pkg, null, 2) + "\n");
 
-const sidecarConfig = getCurrentSidecar(RUST_TARGET)
+const RUST_TARGET = Bun.env.TAURI_ENV_TARGET_TRIPLE;
+const sidecarConfig = getCurrentSidecar(RUST_TARGET);
+const binaryName = windowsify("nikcli");
 
-const binaryPath = windowsify(`../nikcli/dist/${sidecarConfig.ocBinary}/bin/nikcli`)
+// CI path: download the already-built CLI artifact uploaded by the publish job
+// (`.github/workflows/publish.yml` → `nikcli-cli`) instead of rebuilding the CLI
+// on every desktop runner. Rebuilding the CLI cross-platform during sidecar prep
+// is fragile — Bun's "remap bin" step fails on Windows with
+// `could not create process` — and the CLI binary is identical to what publish
+// just produced, so there's nothing to gain from rebuilding it per platform.
+const runID = Bun.env.CLI_ARTIFACT_RUN_ID;
 
-await $`cd ../nikcli && bun run build --single --skip-install`
+if (runID) {
+  const dir = "src-tauri/target/nikcli-binaries";
+  await $`mkdir -p ${dir}`;
+  // The `nikcli-cli` artifact uploads `packages/nikcli/dist`, so once extracted
+  // the binary lives at `${dir}/packages/nikcli/dist/<ocBinary>/bin/<name>`.
+  await $`gh run download ${runID} -n nikcli-cli -D ${dir}`;
+  await copyBinaryToSidecarFolder(
+    windowsify(
+      `${dir}/packages/nikcli/dist/${sidecarConfig.ocBinary}/bin/${binaryName}`,
+    ),
+    RUST_TARGET,
+  );
+  process.exit(0);
+}
 
-await copyBinaryToSidecarFolder(binaryPath, RUST_TARGET)
+// Local path: build the CLI from source and copy it into the Tauri sidecars
+// directory. Used by `bun run native:dev` on a developer machine.
+const binaryPath = windowsify(
+  `../nikcli/dist/${sidecarConfig.ocBinary}/bin/${binaryName}`,
+);
+await $`cd ../nikcli && bun run build --single --skip-install`;
+await copyBinaryToSidecarFolder(binaryPath, RUST_TARGET);


### PR DESCRIPTION
## What

Fixes two unrelated CI failures in the `desktop / build` matrix
(`454b0d918 ci(desktop): full platform coverage + Tauri auto-updater`):

- **Windows (x86_64-pc-windows-msvc)** — `beforeBuildCommand` died with
  `Bun failed to remap this bin to its proper location within node_modules`
  / `could not create process` during `bun run prepare:sidecar`.
- **macOS (aarch64-apple-darwin)** — `failed to run command security import:
  failed to import keychain certificate` because the `APPLE_CERTIFICATE`
  secret is malformed and Tauri was unconditionally importing it.

## How

### 1. Use the prebuilt CLI sidecar in CI

The publish job already produces the CLI for every target and uploads it
as the `nikcli-cli` workflow artifact. There's no reason to rebuild it on
every desktop runner — the cross-platform rebuild during sidecar prep is
exactly what dies on Windows.

- `packages/desktop/scripts/predev.ts` now downloads the artifact via
  `gh run download` when `CLI_ARTIFACT_RUN_ID` is set, with the local
  build as a fallback for `bun run native:dev`.
- `.github/workflows/publish.yml` exposes `run_id` as a workflow output.
- `.github/workflows/ci-pipeline.yml` threads `cli_run_id` into the
  desktop workflow input.
- `.github/workflows/desktop-release.yml` accepts the new `cli_run_id`
  input (workflow_call + workflow_dispatch) and exports it as
  `CLI_ARTIFACT_RUN_ID` for Tauri's beforeBuildCommand.

### 2. Drop Apple code signing

Code signing isn't required for the desktop CI pipeline (users get a
first-launch Gatekeeper prompt — right-click → Open — until we set up
proper notarization). The build step no longer passes any `APPLE_*`
env vars, so Tauri skips `security import` entirely.

## Verification

- `bunx tsc --noEmit -p tsconfig.json` on `packages/desktop` → clean.
- All three modified workflow YAMLs parse with PyYAML.
- Will be confirmed end-to-end on the next `desktop / build` matrix run
  (the desktop job already fails today on every run that hits the broken
  matrix rows, so green on Windows + macOS is the regression bar).

## Risk

Low. The Windows path used to fail 100% of the time; this replaces it
with a known-good artifact download. The macOS path used to fail on
arm64 only (x86_64 succeeded because the broken keychain import was
shorter-lived there); this skips it everywhere, producing unsigned .app
bundles that still install and run. Local `bun run native:dev` is
unchanged because `CLI_ARTIFACT_RUN_ID` is empty in that context.