### PR TITLE
feat(sync): local session journaling, idempotent remote sync, bootstrap wiring

### DIFF
--- a/docs/sync-architecture.md
+++ b/docs/sync-architecture.md
@@ -1,0 +1,121 @@
+# Sync architecture
+
+How nikcli keeps instances, workspaces and sessions on a single, replayable
+backend — locally and (optionally) across machines through a remote hub.
+
+## The unified event log
+
+Everything flows through one SQLite table, `sync_event` (see
+`packages/nikcli/src/sync/sync.sql.ts`):
+
+| column                  | meaning                                                            |
+| ----------------------- | ------------------------------------------------------------------ |
+| `project_id`            | owning project                                                     |
+| `aggregate`             | the entity the event belongs to (`wrk_…`, `ses_…`)                 |
+| `seq`                   | per-`(project, aggregate)` monotonic sequence (from `sync_sequence`) |
+| `type` / `data`         | event envelope (`{ type, properties }`)                            |
+| `workspace_id`          | denormalized routing metadata (nullable)                           |
+| `origin` / `origin_seq` | `local` or `remote:<client>`; the origin server's seq when remote  |
+
+Appends go through `Sync.emitRaw(projectID, aggregate, data, options?)`
+(`packages/nikcli/src/sync/index.ts`), which reserves the next sequence
+number and inserts atomically (`BEGIN IMMEDIATE`, safe across processes
+sharing `nikcli.db`). Compaction trims aggregates past 1000 events down
+to 500; snapshots make that safe (below).
+
+### Writers
+
+- **Workspace event loop** (`workspace/index.ts` + `workspace/sync-bridge.ts`):
+  events observed from a remote workspace's SSE stream (session status,
+  permissions, questions, …) are journaled under the workspace id, plus
+  lifecycle events (`workspace.created`, `workspace.removed`, …) used by the
+  projector to rebuild the workspace row from cold start.
+- **Session sync bridge** (`session/sync-bridge.ts`): restore events of
+  *local* sessions (not bound to a workspace) are journaled under the
+  session id. Workspace-bound sessions are skipped — the workspace loop
+  owns them. Opt out with `NIKCLI_DISABLE_SESSION_JOURNAL=1`.
+- **Remote sync** (below): events received from the hub are replayed into
+  the local log with `origin="remote:<client>"` so they are never pushed
+  back.
+
+### Readers
+
+- **Workspace restore** (`Workspace.restore` → `buildRestorePayload`):
+  replays the workspace aggregate, filtered to client-facing restore event
+  types (lifecycle events stay internal to projection).
+- **Incremental catch-up**: `GET /experimental/workspace/:id/events?from=<seq>`
+  returns sequenced events past the client's last seen `seq` — the recovery
+  path for TUI reconnects and mobile resume.
+- **Projection with snapshots** (`sync/projector.ts`, `sync/reducer.ts`,
+  `sync/snapshot.ts`): pure reducers replay an aggregate on top of the last
+  snapshot (`sync_snapshot`), re-snapshotting every N events. Snapshots are
+  cache, not source of truth: corruption falls back to full replay.
+
+## Remote sync (optional, hub-and-spoke)
+
+Disabled unless configured — nikcli is 100% local by default.
+
+```sh
+export NIKCLI_REMOTE_URL=https://s.nikcli.store
+export NIKCLI_REMOTE_TOKEN=<token with cli-sync scope>
+# optional: keep bootstrap from autostarting (explicit commands still work)
+export NIKCLI_REMOTE_AUTOSTART=false
+```
+
+`RemoteSync.start({ url, token, projectID })` (`sync/remote-sync.ts`) runs
+three loops:
+
+1. **Subscribe**: SSE from `GET /sync/stream`; received events are replayed
+   locally with a `remote:` origin.
+2. **Push**: local `Sync.emitRaw` appends are enqueued in `sync_outbox`
+   (`sync/outbox.ts`) and drained every 5s via `POST /sync/event`.
+   The outbox is offline-first: writes always succeed locally; the backlog
+   drains on reconnect with exponential backoff (1s → cap 24h, then failed).
+3. **Renumbering**: the hub renumbers received events per aggregate and
+   records the client's seq in `origin_seq` (last-writer-wins per
+   `(aggregate, seq)`).
+
+Starts are idempotent per `(url, projectID)`: bootstrap
+(`sync/cli-init.ts`, wired in `project/bootstrap.ts`), `nikcli serve` and
+`nikcli sync` share one connection instead of stacking hooks and timers.
+Server-side, `/sync/*` routes (`server/routes/sync.ts`) require a Bearer
+token with `cli-sync` or `studio` scope (`mobile/auth.sql.ts`).
+
+`nikcli sync status` shows connection, last seq, and outbox depth.
+
+## Instance hot reload
+
+Instances reload their configuration surface in-process, no restart:
+
+- Per-instance caches opt in with `InstanceState.make(init, { reloadable: true })`
+  (`effect/instance-state.ts`); Config opts in, so agents, commands,
+  permissions and plugins re-read from disk on the next access.
+- `InstanceReload` (`project/reload.ts`) watches the global `nikcli.json`,
+  the project `nikcli.json`, and `.nikcli` config directories (300ms
+  debounce, serialized per directory) and invalidates the reloadable caches.
+- Every reload is announced as `instance.reload.started` /
+  `instance.reloaded` on the bus — and therefore on the server's SSE
+  stream — so connected clients refetch instead of polling.
+- Runtime state (bus subscriptions, live sessions, loop engines,
+  schedulers) is intentionally untouched; that is what makes reloading safe
+  mid-session.
+- Explicit trigger: `POST /config/reload`. Opt out of the watcher with
+  `NIKCLI_DISABLE_HOT_RELOAD=1`.
+
+## Migration notes
+
+Older builds buffered workspace restore events in a JSON column
+(`workspace.events`). Migrations `20260630000000_sync_unify` and
+`20260630000100_workspace_drop_events` import that data into `sync_event`
+and drop the column; `sync/migrate-from-workspace.ts` is the idempotent
+importer. `sync_event` has been the single source of truth since.
+
+## Environment variables
+
+| variable                         | effect                                             |
+| -------------------------------- | -------------------------------------------------- |
+| `NIKCLI_REMOTE_URL`              | hub base URL; enables remote sync (with token)     |
+| `NIKCLI_REMOTE_TOKEN`            | Bearer token (`cli-sync` scope)                    |
+| `NIKCLI_REMOTE_AUTOSTART=false`  | don't autostart from bootstrap                     |
+| `NIKCLI_DISABLE_SESSION_JOURNAL` | don't journal local session events                 |
+| `NIKCLI_DISABLE_HOT_RELOAD`      | don't watch config files for instance hot reload   |

--- a/packages/nikcli/src/flag/flag.ts
+++ b/packages/nikcli/src/flag/flag.ts
@@ -20,6 +20,18 @@ export namespace Flag {
   // Opt out of the in-process config hot reload (instance reload on config
   // file changes). Reload can still be triggered explicitly via the API.
   export const NIKCLI_DISABLE_HOT_RELOAD = truthy("NIKCLI_DISABLE_HOT_RELOAD")
+  // Opt out of journaling local (non-workspace) session restore events into
+  // the unified sync_event log.
+  export const NIKCLI_DISABLE_SESSION_JOURNAL = truthy("NIKCLI_DISABLE_SESSION_JOURNAL")
+  // Optional hub-and-spoke remote sync. Setting both URL and TOKEN enables
+  // it; AUTOSTART=false keeps bootstrap from starting it automatically
+  // (explicit `nikcli sync` / `nikcli serve` still can).
+  export const NIKCLI_REMOTE_URL = process.env["NIKCLI_REMOTE_URL"]
+  export const NIKCLI_REMOTE_TOKEN = process.env["NIKCLI_REMOTE_TOKEN"]
+  export const NIKCLI_REMOTE_AUTOSTART = (() => {
+    const value = process.env["NIKCLI_REMOTE_AUTOSTART"]?.toLowerCase()
+    return value !== "false" && value !== "0"
+  })()
   export const NIKCLI_DISABLE_MODELS_FETCH = truthy("NIKCLI_DISABLE_MODELS_FETCH")
   export const NIKCLI_DISABLE_CLAUDE_CODE = truthy("NIKCLI_DISABLE_CLAUDE_CODE")
   export const NIKCLI_DISABLE_CLAUDE_CODE_PROMPT =

--- a/packages/nikcli/src/project/bootstrap.ts
+++ b/packages/nikcli/src/project/bootstrap.ts
@@ -193,6 +193,29 @@ export async function InstanceBootstrap() {
     )
   }
 
+  // Unified backend: journal local (non-workspace) session restore events
+  // into sync_event, same log the workspace loops and remote sync use.
+  // Imported lazily: the bridge reaches into session/, which would close
+  // an import cycle with this module if imported statically.
+  if (!Flag.NIKCLI_DISABLE_SESSION_JOURNAL) {
+    try {
+      const { SessionSyncBridge } = await import("../session/sync-bridge")
+      Instance.registerDisposer(SessionSyncBridge.init())
+    } catch (error) {
+      Log.Default.warn("session sync bridge init failed", { error })
+    }
+  }
+
+  // Optional hub-and-spoke remote sync (NIKCLI_REMOTE_URL + _TOKEN).
+  // Idempotent per (url, project); no-op when env is not configured.
+  background(
+    "remote-sync",
+    import("@/sync/cli-init").then(async ({ SyncCliInit }) => {
+      const stop = await SyncCliInit.initRemoteSyncFromEnv()
+      if (stop) Instance.registerDisposer(stop)
+    }),
+  )
+
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {
       await runProject(

--- a/packages/nikcli/src/session/sync-bridge.ts
+++ b/packages/nikcli/src/session/sync-bridge.ts
@@ -1,0 +1,75 @@
+/**
+ * Bridge between local session activity and the unified `sync_event` log.
+ *
+ * The workspace event loop already journals events for sessions that live
+ * inside a workspace (aggregate = workspace id). This bridge covers the
+ * other half of the "one backend for sessions + workspaces" goal: sessions
+ * of the local instance that are NOT bound to a workspace. Their restore
+ * events (created/updated/deleted/status/idle, permission and question
+ * asks/replies) are journaled under the session id as aggregate, so any
+ * client — mobile resume, remote hub, a second machine — can catch up
+ * from the same sequenced log it already uses for workspaces.
+ *
+ * Workspace-bound sessions are skipped here: the workspace loop owns them,
+ * and journaling them twice would inflate the log with duplicates.
+ */
+import { Bus } from "@/bus"
+import { Instance } from "@/project/instance"
+import { Log } from "@/util/log"
+import { Sync } from "@/sync"
+import { SessionRepo } from "./repo"
+
+const log = Log.create({ service: "session-sync-bridge" })
+
+/** Same shape the workspace loop persists: client-facing restore events. */
+const JOURNAL_EVENT_TYPES = new Set([
+  "session.created",
+  "session.updated",
+  "session.deleted",
+  "session.status",
+  "session.idle",
+  "permission.asked",
+  "permission.replied",
+  "question.asked",
+  "question.replied",
+  "question.rejected",
+])
+
+function eventSessionID(properties: any): string | undefined {
+  if (!properties || typeof properties !== "object") return
+  if (typeof properties.sessionID === "string") return properties.sessionID
+  if (typeof properties.info?.id === "string" && properties.info.id.startsWith("ses")) return properties.info.id
+  if (typeof properties.info?.sessionID === "string") return properties.info.sessionID
+}
+
+export namespace SessionSyncBridge {
+  /**
+   * Subscribe the current instance's bus to the unified log. Returns the
+   * unsubscribe function; the caller registers it as an instance disposer.
+   */
+  export function init(): () => void {
+    const projectID = Instance.project.id
+    return Bus.subscribeAll((event: { type?: string; properties?: any }) => {
+      if (!event?.type || !JOURNAL_EVENT_TYPES.has(event.type)) return
+      const sessionID = eventSessionID(event.properties)
+      if (!sessionID) return
+
+      // Workspace-bound sessions are journaled by the workspace event loop
+      // under the workspace aggregate; a missing row (already-deleted
+      // session emitting session.deleted) is journaled as local.
+      const session = SessionRepo.get(sessionID)
+      if (session?.workspaceID) return
+
+      void Sync.emitRaw(projectID, sessionID, {
+        type: event.type,
+        properties: event.properties ?? {},
+      }).catch((error) => {
+        log.warn("session event journal failed", {
+          sessionID,
+          type: event.type,
+          error,
+        })
+      })
+    })
+  }
+}

--- a/packages/nikcli/src/sync/cli-init.ts
+++ b/packages/nikcli/src/sync/cli-init.ts
@@ -1,0 +1,39 @@
+/**
+ * Bootstrap wiring for the optional remote sync (plan phase 3.4).
+ *
+ * When `NIKCLI_REMOTE_URL` + `NIKCLI_REMOTE_TOKEN` are set, every
+ * bootstrapped instance connects its project to the remote hub — not just
+ * the headless `nikcli serve` path. `RemoteSync.start` is idempotent per
+ * (url, projectID), so bootstrap, `serve`, and `nikcli sync` can all call
+ * it without stacking connections. `NIKCLI_REMOTE_AUTOSTART=false` opts
+ * bootstrap out while keeping the explicit commands working.
+ */
+import { Flag } from "@/flag/flag"
+import { Instance } from "@/project/instance"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "sync.cli-init" })
+
+export namespace SyncCliInit {
+  /**
+   * Start remote sync for the current instance's project if the env is
+   * configured. Returns a stop function for the instance disposer, or
+   * undefined when remote sync is not configured.
+   */
+  export async function initRemoteSyncFromEnv(): Promise<(() => Promise<void>) | undefined> {
+    const url = Flag.NIKCLI_REMOTE_URL?.replace(/\/$/, "")
+    const token = Flag.NIKCLI_REMOTE_TOKEN
+    if (!url || !token) return undefined
+    if (!Flag.NIKCLI_REMOTE_AUTOSTART) {
+      log.info("remote sync configured but autostart disabled")
+      return undefined
+    }
+
+    const projectID = Instance.project.id
+    // Lazy import keeps the remote client out of the local-only path.
+    const { RemoteSync } = await import("./remote-sync")
+    const handle = await RemoteSync.start({ url, token, projectID })
+    log.info("remote sync started from bootstrap", { url, projectID })
+    return () => handle.stop()
+  }
+}

--- a/packages/nikcli/src/sync/remote-sync.ts
+++ b/packages/nikcli/src/sync/remote-sync.ts
@@ -22,7 +22,7 @@
 import { Log } from "@/util/log"
 import { Database } from "@/database/database"
 import { eq } from "drizzle-orm"
-import { syncOutbox, syncEvent } from "./sync.sql"
+import { syncEvent } from "./sync.sql"
 import { RemoteSyncClient } from "./remote-client"
 import { Outbox } from "./outbox"
 import { Sync, type SyncEventRecord } from "./index"
@@ -47,6 +47,49 @@ export type RemoteSyncHandle = {
 }
 
 export namespace RemoteSync {
+  // One handle per (url, projectID): repeated starts (bootstrap + serve +
+  // `nikcli sync`) share the same connection instead of stacking emitRaw
+  // wrappers and duplicate drain timers.
+  const active = new Map<string, { handle: RemoteSyncHandle; url: string }>()
+
+  // Single global emitRaw hook. Each active target gets local events
+  // enqueued; the hook is installed once and removed when the last
+  // remote sync stops.
+  const enqueueTargets = new Set<string>()
+  let removeEmitHook: (() => void) | undefined
+
+  function ensureEmitHook() {
+    if (removeEmitHook) return
+    const originalEmitRaw = Sync.emitRaw
+    ;(Sync as any).emitRaw = async (
+      projectID: string,
+      aggregate: string,
+      data: unknown,
+      options: {
+        workspaceID?: string
+        origin?: string
+        originSeq?: number
+      } = {},
+    ) => {
+      const isLocal = !options.origin || options.origin === "local"
+      const record = await originalEmitRaw(projectID, aggregate, data, options)
+      if (isLocal) {
+        for (const target of enqueueTargets) {
+          try {
+            Outbox.enqueue(record.id, target)
+          } catch (error) {
+            log.warn("outbox enqueue failed", { target, error })
+          }
+        }
+      }
+      return record
+    }
+    removeEmitHook = () => {
+      ;(Sync as any).emitRaw = originalEmitRaw
+      removeEmitHook = undefined
+    }
+  }
+
   /**
    * Resolve a `SyncEventRecord` from the outbox row's `eventId` so it
    * can be pushed to the remote.
@@ -77,7 +120,27 @@ export namespace RemoteSync {
     }
   }
 
-  export async function start(opts: RemoteSyncOptions): Promise<RemoteSyncHandle> {
+  // Concurrent starts for the same (url, projectID) share the in-flight
+  // promise instead of racing past the active check.
+  const starting = new Map<string, Promise<RemoteSyncHandle>>()
+
+  export function start(opts: RemoteSyncOptions): Promise<RemoteSyncHandle> {
+    const key = `${opts.url}::${opts.projectID}`
+    const existing = active.get(key)
+    if (existing) return Promise.resolve(existing.handle)
+    let inflight = starting.get(key)
+    if (!inflight) {
+      inflight = doStart(opts, key)
+      starting.set(key, inflight)
+      const settle = () => {
+        if (starting.get(key) === inflight) starting.delete(key)
+      }
+      inflight.then(settle, settle)
+    }
+    return inflight
+  }
+
+  async function doStart(opts: RemoteSyncOptions, key: string): Promise<RemoteSyncHandle> {
     const clientId = opts.clientId ?? "cli"
     const originTag = `remote:${clientId}`
     const drainInterval = opts.drainIntervalMs ?? 5_000
@@ -126,38 +189,21 @@ export namespace RemoteSync {
       })
     }, drainInterval)
 
-    // Auto-enqueue: monkey-patch-free integration via wrapping the
-    // public Sync.emitRaw. The wrapper records the event id in the
-    // outbox right after the row is inserted.
-    const originalEmitRaw = Sync.emitRaw
-    ;(Sync as any).emitRaw = async (
-      projectID: string,
-      aggregate: string,
-      data: unknown,
-      options: {
-        workspaceID?: string
-        origin?: string
-        originSeq?: number
-      } = {},
-    ) => {
-      const isLocal = !options.origin || options.origin === "local"
-      const record = await originalEmitRaw(projectID, aggregate, data, options)
-      if (isLocal) {
-        try {
-          Outbox.enqueue(record.id, opts.url)
-        } catch (error) {
-          log.warn("outbox enqueue failed", { error })
-        }
-      }
-      return record
-    }
+    // Auto-enqueue: local events recorded via the shared emitRaw hook land
+    // in the outbox for this target right after the row is inserted.
+    enqueueTargets.add(opts.url)
+    ensureEmitHook()
 
-    return {
+    const handle: RemoteSyncHandle = {
       stop: async () => {
         clearInterval(drainTimer)
         client.stop()
-        // Restore the original emitRaw so a subsequent start works
-        ;(Sync as any).emitRaw = originalEmitRaw
+        active.delete(key)
+        // Only stop enqueuing for this url when no other project still
+        // syncs to it; remove the hook entirely when nothing is active.
+        const urlStillUsed = [...active.values()].some((entry) => entry.url === opts.url)
+        if (!urlStillUsed) enqueueTargets.delete(opts.url)
+        if (active.size === 0) removeEmitHook?.()
         connected = false
         log.info("remote sync stopped")
       },
@@ -170,5 +216,8 @@ export namespace RemoteSync {
         }
       },
     }
+
+    active.set(key, { handle, url: opts.url })
+    return handle
   }
 }

--- a/packages/nikcli/test/sync/remote-idempotent.test.ts
+++ b/packages/nikcli/test/sync/remote-idempotent.test.ts
@@ -1,0 +1,62 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterAll, describe, expect, it } from "bun:test"
+
+const testDir = await fs.mkdtemp(path.join(os.tmpdir(), "nikcli-remote-idem-"))
+process.env.NIKCLI_TEST_HOME ??= testDir
+process.env.NIKCLI_DB ??= path.join(testDir, "nikcli.db")
+
+const { RemoteSync } = await import("@/sync/remote-sync")
+const { Sync } = await import("@/sync")
+const { Outbox } = await import("@/sync/outbox")
+
+// Nothing listens here: pushes fail fast and stay in the outbox, which is
+// exactly what the offline-first path expects.
+const url = "http://127.0.0.1:59742"
+const run = Math.random().toString(36).slice(2)
+
+afterAll(async () => {
+  await fs.rm(testDir, { recursive: true, force: true })
+})
+
+describe("RemoteSync.start", () => {
+  it("is idempotent per (url, project) and enqueues local events exactly once", async () => {
+    const projectID = `proj_ri_${run}`
+    // Long drain interval: the test controls the outbox state directly.
+    const first = await RemoteSync.start({ url, token: "t", projectID, drainIntervalMs: 3_600_000 })
+    const again = await RemoteSync.start({ url, token: "t", projectID, drainIntervalMs: 3_600_000 })
+    const other = await RemoteSync.start({
+      url,
+      token: "t",
+      projectID: `proj_ri_other_${run}`,
+      drainIntervalMs: 3_600_000,
+    })
+
+    try {
+      expect(again).toBe(first)
+      expect(other).not.toBe(first)
+
+      const before = Outbox.status(url).total
+      await Sync.emitRaw(projectID, `wrk_ri_${run}`, { type: "session.idle", properties: {} })
+      expect(Outbox.status(url).total).toBe(before + 1)
+
+      // Remote-origin events are never pushed back.
+      await Sync.emitRaw(projectID, `wrk_ri_${run}`, { type: "session.idle", properties: {} }, { origin: "remote:hub" })
+      expect(Outbox.status(url).total).toBe(before + 1)
+    } finally {
+      await first.stop()
+      await other.stop()
+    }
+
+    // With every sync stopped the emit hook is removed: no new enqueues.
+    const after = Outbox.status(url).total
+    await Sync.emitRaw(projectID, `wrk_ri_${run}`, { type: "session.idle", properties: {} })
+    expect(Outbox.status(url).total).toBe(after)
+
+    // A fresh start works after full teardown.
+    const restarted = await RemoteSync.start({ url, token: "t", projectID, drainIntervalMs: 3_600_000 })
+    expect(restarted).not.toBe(first)
+    await restarted.stop()
+  })
+})

--- a/packages/nikcli/test/sync/session-bridge.test.ts
+++ b/packages/nikcli/test/sync/session-bridge.test.ts
@@ -1,0 +1,72 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterAll, describe, expect, it } from "bun:test"
+import z from "zod"
+
+const testDir = await fs.mkdtemp(path.join(os.tmpdir(), "nikcli-session-bridge-"))
+process.env.NIKCLI_TEST_HOME ??= testDir
+process.env.NIKCLI_DB ??= path.join(testDir, "nikcli.db")
+
+const { Instance } = await import("@/project/instance")
+const { Bus } = await import("@/bus")
+const { BusEvent } = await import("@/bus/bus-event")
+const { SessionStatus } = await import("@/session/status")
+const { SessionSyncBridge } = await import("@/session/sync-bridge")
+const { SyncStorage } = await import("@/sync")
+
+const NoopEvent = BusEvent.define("test.session-bridge.noop", z.object({ sessionID: z.string() }))
+
+afterAll(async () => {
+  await fs.rm(testDir, { recursive: true, force: true })
+})
+
+async function waitForEvents(projectID: string, aggregate: string, count: number, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const events = await SyncStorage.getEvents(projectID, aggregate)
+    if (events.length >= count) return events
+    await Bun.sleep(25)
+  }
+  return SyncStorage.getEvents(projectID, aggregate)
+}
+
+describe("SessionSyncBridge", () => {
+  it("journals local session restore events and stops after unsubscribe", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "nikcli-session-bridge-project-"))
+    const run = Math.random().toString(36).slice(2)
+    const sessionID = `ses_bridge_${run}`
+
+    try {
+      await Instance.provide({
+        directory,
+        fn: async () => {
+          const projectID = Instance.project.id
+          const unsubscribe = SessionSyncBridge.init()
+          try {
+            await Bus.publish(SessionStatus.Event.Idle, { sessionID })
+            const events = await waitForEvents(projectID, sessionID, 1)
+            expect(events).toHaveLength(1)
+            expect(events[0].type).toBe("session.idle")
+            expect((events[0].data as any).properties.sessionID).toBe(sessionID)
+
+            // Event types outside the restore set are not journaled.
+            await Bus.publish(NoopEvent, { sessionID: `${sessionID}_noop` })
+            await Bun.sleep(100)
+            expect(await SyncStorage.getEvents(projectID, `${sessionID}_noop`)).toHaveLength(0)
+          } finally {
+            unsubscribe()
+          }
+
+          // After unsubscribe nothing new lands in the journal.
+          await Bus.publish(SessionStatus.Event.Idle, { sessionID: `${sessionID}_after` })
+          await Bun.sleep(100)
+          expect(await SyncStorage.getEvents(projectID, `${sessionID}_after`)).toHaveLength(0)
+        },
+      })
+    } finally {
+      await Instance.provide({ directory, fn: () => Instance.dispose() })
+      await fs.rm(directory, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes # (follow-up to #133, requested directly)

### Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Completes the remaining gaps of the unify-sessions-workspace plan (phases 2/3/4.3). An audit against the plan found three concrete holes:

**Local sessions were not journaled** — only remote-workspace events reached `sync_event`. New `session/sync-bridge.ts` subscribes to the instance bus and journals restore events (created/updated/deleted/status/idle, permission, question) of local sessions under the session id aggregate. Workspace-bound sessions are skipped because the workspace event loop already owns them, so nothing is journaled twice. Opt out with `NIKCLI_DISABLE_SESSION_JOURNAL`.

**`RemoteSync.start` was not idempotent** — each call stacked another `Sync.emitRaw` wrapper and drain timer, and out-of-order stops broke the restore chain. Now there is one handle per `(url, projectID)` (concurrent starts share the in-flight promise) and a single global emit hook that feeds the outbox for all active targets and is removed when the last sync stops. Remote-origin events are never pushed back.

**Remote sync only started from `nikcli serve`** — plan items 3.4/3.5 were missing. New `sync/cli-init.ts` exposes `initRemoteSyncFromEnv()`, wired into `InstanceBootstrap`, so any instance connects when `NIKCLI_REMOTE_URL`/`NIKCLI_REMOTE_TOKEN` are set; `NIKCLI_REMOTE_AUTOSTART=false` opts bootstrap out. The env vars are now typed `Flag` entries.

Also adds `docs/sync-architecture.md` (plan 4.3): the unified log's writers/readers, snapshots and compaction, the remote hub protocol and offline-first outbox, instance hot reload, migration notes and an env-var reference.

### How did you verify your code works?

- `bun run typecheck` clean.
- Full suite (excluding benchmarks): 1851 pass, 1 fail — the known `ci-report-failure.ts` GITHUB_TOKEN test that fails identically on pristine `live-main` in this sandboxed environment (the network proxy answers 403 instead of a missing-token error).
- New tests: session bridge journaling, non-restore event filtering and unsubscribe teardown; remote sync idempotence, enqueue-exactly-once, full teardown and clean restart.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01728GkGpNFCsWGJEqMPAmgq

---
_Generated by [Claude Code](https://claude.ai/code/session_01728GkGpNFCsWGJEqMPAmgq)_