### PR TITLE
feat(sync): enforce token scopes, rate-limit and audit hub event pushes

### DIFF
--- a/docs/sync-architecture.md
+++ b/docs/sync-architecture.md
@@ -78,8 +78,19 @@ three loops:
 Starts are idempotent per `(url, projectID)`: bootstrap
 (`sync/cli-init.ts`, wired in `project/bootstrap.ts`), `nikcli serve` and
 `nikcli sync` share one connection instead of stacking hooks and timers.
-Server-side, `/sync/*` routes (`server/routes/sync.ts`) require a Bearer
-token with `cli-sync` or `studio` scope (`mobile/auth.sql.ts`).
+
+### Hub-side security
+
+- **Scope enforcement**: when a Bearer token is presented, `/sync/*`
+  requires the `cli-sync` or `studio` scope (`mobile/auth.sql.ts`); a
+  paired mobile token gets 403. Operator-level auth paths (basic auth,
+  Tailscale identity) pass through. Create a sync token with
+  `nikcli sync token create --name <label>`.
+- **Rate limiting**: `POST /sync/event` allows 100 events/min per token
+  (fixed window, 429 + `retry-after` beyond it), so a stolen token cannot
+  flood the log.
+- **Audit**: every accepted push is logged with token id/name, aggregate,
+  type and the renumbered sequence.
 
 `nikcli sync status` shows connection, last seq, and outbox depth.
 

--- a/packages/nikcli/src/cli/cmd/sync.ts
+++ b/packages/nikcli/src/cli/cmd/sync.ts
@@ -1,9 +1,6 @@
 import { cmd } from "./cmd"
 import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"
-import { Effect } from "effect"
-import { runPromiseWithLayer, withCurrentInstance } from "@/effect"
-import { Project } from "@/project/project"
 import { Outbox } from "@/sync/outbox"
 import { RemoteSync } from "@/sync/remote-sync"
 
@@ -62,6 +59,32 @@ export const SyncCommand = cmd({
         handler: async () => {
           console.log("disconnect is implicit — stopping the CLI will close the connection")
           console.log("queued events in the outbox will be sent on next connect")
+        },
+      })
+      .command({
+        command: "token create",
+        describe: "create a cli-sync scoped token for connecting a CLI to this hub",
+        builder: (inner) =>
+          inner
+            .option("name", {
+              type: "string",
+              default: "cli-sync",
+              describe: "token label",
+            })
+            .option("expiry-days", {
+              type: "number",
+              describe: "optional token expiry in days",
+            }),
+        handler: async (args) => {
+          const { MobileAuth } = await import("@/mobile/auth")
+          const created = await MobileAuth.create({
+            name: String(args.name || "cli-sync"),
+            expiresInDays: args.expiryDays ? Number(args.expiryDays) : undefined,
+            scope: "cli-sync",
+          })
+          console.log(`token id: ${created.info.id} (scope: cli-sync)`)
+          console.log(`NIKCLI_REMOTE_TOKEN=${created.token}`)
+          console.log("store the token now — it cannot be shown again")
         },
       })
       .demandCommand()

--- a/packages/nikcli/src/mobile/auth.ts
+++ b/packages/nikcli/src/mobile/auth.ts
@@ -12,6 +12,14 @@ function getChanges(result: void | RunResult): number {
 }
 
 export namespace MobileAuth {
+  /**
+   * Token scope: `mobile` (paired mobile device), `cli-sync` (CLI↔hub sync),
+   * `studio` (desktop UI). The `/sync/*` routes require `cli-sync` or
+   * `studio` when a bearer token is used.
+   */
+  export const Scope = z.enum(["mobile", "cli-sync", "studio"])
+  export type Scope = z.infer<typeof Scope>
+
   export const Token = z
     .object({
       id: z.string(),
@@ -20,6 +28,7 @@ export namespace MobileAuth {
       createdAt: z.number(),
       lastUsedAt: z.number().optional(),
       expiresAt: z.number().optional(),
+      scope: z.string().default("mobile"),
     })
     .meta({ ref: "MobileAuthToken" })
 
@@ -68,6 +77,7 @@ export namespace MobileAuth {
       createdAt: row.createdAt,
       lastUsedAt: row.lastUsedAt ?? undefined,
       expiresAt: row.expiresAt ?? undefined,
+      scope: row.scope ?? "mobile",
     }
   }
 
@@ -78,6 +88,7 @@ export namespace MobileAuth {
       createdAt: row.createdAt,
       lastUsedAt: row.lastUsedAt ?? undefined,
       expiresAt: row.expiresAt ?? undefined,
+      scope: row.scope ?? "mobile",
     }
   }
 
@@ -147,7 +158,7 @@ export namespace MobileAuth {
       .sort((a, b) => b.createdAt - a.createdAt)
   }
 
-  export async function create(input?: { name?: string; expiresInDays?: number }) {
+  export async function create(input?: { name?: string; expiresInDays?: number; scope?: Scope }) {
     await ensureMigrated()
     const token = `nkm_${randomBytes(24).toString("base64url")}`
     const info: typeof mobileTokens.$inferInsert = {
@@ -157,6 +168,7 @@ export namespace MobileAuth {
       createdAt: Date.now(),
       lastUsedAt: null,
       expiresAt: input?.expiresInDays ? Date.now() + input.expiresInDays * 24 * 60 * 60 * 1000 : null,
+      scope: input?.scope ?? "mobile",
     }
 
     db().insert(mobileTokens).values(info).run()
@@ -171,6 +183,7 @@ export namespace MobileAuth {
         createdAt: info.createdAt,
         lastUsedAt: info.lastUsedAt ?? undefined,
         expiresAt: info.expiresAt ?? undefined,
+        scope: info.scope,
       }),
     }
   }

--- a/packages/nikcli/src/server/routes/sync.ts
+++ b/packages/nikcli/src/server/routes/sync.ts
@@ -15,11 +15,48 @@ import { describeRoute, resolver, validator } from "hono-openapi"
 import { z } from "zod"
 import { eq, and, gt, sql } from "drizzle-orm"
 import { Database } from "@/database/database"
+import type { MobileAuth } from "@/mobile/auth"
 import { syncEvent, syncOutbox } from "@/sync/sync.sql"
 import { GlobalBus } from "@/bus/global"
 import { Log } from "@/util/log"
 
 const log = Log.create({ service: "server.sync" })
+
+// Scopes allowed to use the sync surface when a bearer token is presented.
+// Operator-level auth paths (basic auth, tailscale identity, unsecured
+// loopback server) do not carry a token and pass through.
+const SYNC_SCOPES = new Set(["cli-sync", "studio"])
+
+function syncToken(c: { get?: (key: string) => unknown }): MobileAuth.PublicToken | undefined {
+  return (c as any).get?.("mobileAuth") as MobileAuth.PublicToken | undefined
+}
+
+// Fixed-window rate limit for event pushes (plan mitigation: a stolen token
+// must not be able to flood the log). Keyed by token id, or by the auth
+// path ("operator") when no token is involved.
+const PUSH_WINDOW_MS = 60_000
+const PUSH_LIMIT_PER_WINDOW = 100
+const pushWindows = new Map<string, { windowStart: number; count: number }>()
+
+function pushAllowed(identity: string): { allowed: boolean; retryAfterMs: number } {
+  const now = Date.now()
+  const window = pushWindows.get(identity)
+  if (!window || now - window.windowStart >= PUSH_WINDOW_MS) {
+    // Lazy cleanup: drop stale windows so the map stays bounded.
+    if (pushWindows.size > 1_000) {
+      for (const [key, value] of pushWindows) {
+        if (now - value.windowStart >= PUSH_WINDOW_MS) pushWindows.delete(key)
+      }
+    }
+    pushWindows.set(identity, { windowStart: now, count: 1 })
+    return { allowed: true, retryAfterMs: 0 }
+  }
+  if (window.count >= PUSH_LIMIT_PER_WINDOW) {
+    return { allowed: false, retryAfterMs: window.windowStart + PUSH_WINDOW_MS - now }
+  }
+  window.count++
+  return { allowed: true, retryAfterMs: 0 }
+}
 
 const SyncEventPayload = z.object({
   event: z.object({
@@ -48,6 +85,21 @@ const StreamQuery = z.object({
 })
 
 export const SyncRoutes = new Hono()
+  // Scope enforcement: a bearer-authenticated caller must hold a sync-capable
+  // scope. Tokens are verified by the server-level auth middleware; this
+  // narrows what a valid-but-mobile token may reach.
+  .use("*", async (c, next) => {
+    const token = syncToken(c)
+    if (token && !SYNC_SCOPES.has(token.scope ?? "mobile")) {
+      log.warn("sync access denied: insufficient scope", {
+        tokenID: token.id,
+        scope: token.scope,
+        path: c.req.path,
+      })
+      return c.text("Forbidden: sync requires a cli-sync or studio token", 403)
+    }
+    return next()
+  })
   .post(
     "/event",
     describeRoute({
@@ -57,10 +109,20 @@ export const SyncRoutes = new Hono()
         204: { description: "Event accepted" },
         400: { description: "Invalid payload" },
         401: { description: "Unauthorized" },
+        429: { description: "Rate limit exceeded" },
       },
     }),
     validator("json", SyncEventPayload),
     async (c) => {
+      const token = syncToken(c)
+      const identity = token?.id ?? "operator"
+      const rate = pushAllowed(identity)
+      if (!rate.allowed) {
+        log.warn("sync push rate limited", { identity, path: c.req.path })
+        c.header("retry-after", String(Math.ceil(rate.retryAfterMs / 1000)))
+        return c.text("Rate limit exceeded", 429)
+      }
+
       const body = c.req.valid("json")
       const db = Database.syncDb()
       // Idempotency: skip if the event id already exists
@@ -102,10 +164,14 @@ export const SyncRoutes = new Hono()
           properties: { eventID: body.event.id, seq: inserted },
         },
       })
+      // Audit trail: who pushed what (plan mitigation for stolen tokens).
       log.info("remote event accepted", {
         eventID: body.event.id,
         seq: inserted,
         aggregate: body.event.aggregate,
+        type: body.event.type,
+        tokenID: token?.id ?? "operator",
+        tokenName: token?.name,
       })
       return c.body(null, 204)
     },

--- a/packages/nikcli/test/sync/routes-auth.test.ts
+++ b/packages/nikcli/test/sync/routes-auth.test.ts
@@ -1,0 +1,97 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterAll, describe, expect, it } from "bun:test"
+import { Hono } from "hono"
+
+const testDir = await fs.mkdtemp(path.join(os.tmpdir(), "nikcli-sync-auth-"))
+process.env.NIKCLI_TEST_HOME ??= testDir
+process.env.NIKCLI_DB ??= path.join(testDir, "nikcli.db")
+
+const { SyncRoutes } = await import("@/server/routes/sync")
+
+const run = Math.random().toString(36).slice(2)
+
+afterAll(async () => {
+  await fs.rm(testDir, { recursive: true, force: true })
+})
+
+type FakeToken = { id: string; name: string; scope: string; createdAt: number }
+
+// Mirrors the server-level middleware contract: a verified bearer token is
+// exposed to nested routers via c.set("mobileAuth", token).
+function appWith(token?: FakeToken) {
+  return new Hono()
+    .use("*", async (c, next) => {
+      if (token) (c as any).set("mobileAuth", token)
+      return next()
+    })
+    .route("/sync", SyncRoutes)
+}
+
+let eventCounter = 0
+function pushRequest(projectID: string) {
+  eventCounter++
+  return new Request("http://localhost/sync/event", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      event: {
+        id: `syn_auth_${run}_${eventCounter}`,
+        projectId: projectID,
+        aggregate: `wrk_auth_${run}`,
+        seq: eventCounter,
+        type: "session.idle",
+        data: { type: "session.idle", properties: {} },
+        timestamp: Date.now(),
+      },
+      projectID,
+    }),
+  })
+}
+
+describe("SyncRoutes auth", () => {
+  it("rejects bearer tokens without a sync-capable scope", async () => {
+    const app = appWith({ id: `mat_${run}_mobile`, name: "iphone", scope: "mobile", createdAt: Date.now() })
+
+    const push = await app.request(pushRequest(`proj_auth_${run}`))
+    expect(push.status).toBe(403)
+
+    const stats = await app.request("http://localhost/sync/stats")
+    expect(stats.status).toBe(403)
+  })
+
+  it("accepts cli-sync and studio scopes, and operator (no token) access", async () => {
+    const cliSync = appWith({ id: `mat_${run}_cli`, name: "cli", scope: "cli-sync", createdAt: Date.now() })
+    expect((await cliSync.request(pushRequest(`proj_auth_${run}`))).status).toBe(204)
+
+    const studio = appWith({ id: `mat_${run}_studio`, name: "studio", scope: "studio", createdAt: Date.now() })
+    expect((await studio.request(pushRequest(`proj_auth_${run}`))).status).toBe(204)
+
+    const operator = appWith()
+    expect((await operator.request(pushRequest(`proj_auth_${run}`))).status).toBe(204)
+  })
+
+  it("rate limits event pushes per token", async () => {
+    const token: FakeToken = { id: `mat_${run}_flood`, name: "flood", scope: "cli-sync", createdAt: Date.now() }
+    const app = appWith(token)
+    const projectID = `proj_flood_${run}`
+
+    let limited: Response | undefined
+    for (let i = 0; i < 101; i++) {
+      const res = await app.request(pushRequest(projectID))
+      if (res.status === 429) {
+        limited = res
+        break
+      }
+      expect(res.status).toBe(204)
+    }
+
+    expect(limited).toBeDefined()
+    expect(Number(limited!.headers.get("retry-after"))).toBeGreaterThan(0)
+
+    // Other identities are unaffected by the flooded token's window.
+    const other = appWith({ id: `mat_${run}_other`, name: "other", scope: "cli-sync", createdAt: Date.now() })
+    expect((await other.request(pushRequest(projectID))).status).toBe(204)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes # (follow-up to #134, requested directly)

### Type of change

- [x] New feature
- [x] Bug fix
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Implements the security mitigations the sync plan promised but that were never actually wired up. The `/sync/*` routes' doc comment claimed "the auth middleware in server.ts enforces cli-sync/studio scope" — in reality the `scope` column was written with a default and **never read anywhere**: any valid mobile pairing token could push events into the unified log, with no rate limit.

- **Scope surfacing**: `MobileAuth` now exposes `scope` in its schemas, `create()` accepts it, and `verify()`/`list()` return it. New `nikcli sync token create --name <label>` mints a `cli-sync` scoped token and prints the `NIKCLI_REMOTE_TOKEN` line to copy.
- **Scope enforcement**: a middleware on `/sync/*` rejects bearer tokens whose scope is not `cli-sync` or `studio` with 403. Operator-level auth paths (basic auth, Tailscale identity) don't carry a token and pass through unchanged.
- **Rate limiting**: `POST /sync/event` allows 100 events/min per token (fixed window, keyed by token id or "operator"), returning 429 with a `retry-after` header beyond that; stale windows are cleaned up lazily so the map stays bounded.
- **Audit**: accepted pushes are logged with token id/name, aggregate, event type and the renumbered sequence.

`docs/sync-architecture.md` gains a "Hub-side security" section.

### How did you verify your code works?

- `bun run typecheck` clean.
- Full suite (excluding benchmarks): 1854 pass, 1 fail — the known environment-dependent `ci-report-failure.ts` GITHUB_TOKEN test that fails identically on pristine `live-main` in this sandbox.
- New tests (`test/sync/routes-auth.test.ts`): mobile-scoped token rejected on push and stats; cli-sync/studio/operator accepted; 101st push in a minute rate-limited with `retry-after`; other token identities unaffected by a flooded token's window.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01728GkGpNFCsWGJEqMPAmgq

---
_Generated by [Claude Code](https://claude.ai/code/session_01728GkGpNFCsWGJEqMPAmgq)_