### PR TITLE
fix(deploy): detect unhealthy Railway releases

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -102,7 +102,6 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE || 'nikcli-mobile' }}
-          RAILWAY_HEALTH_URL: ${{ vars.RAILWAY_HEALTH_URL || 'https://nikcli-mobile-production.up.railway.app/global/health' }}
         run: |
           if [ -z "${RAILWAY_TOKEN:-}" ]; then
             echo "✗ RAILWAY_TOKEN not configured — skipping deploy"
@@ -115,16 +114,7 @@ jobs:
             tail -n 30 tmp/railway.log || true
             exit 1
           fi
-          for attempt in $(seq 1 18); do
-            if curl --fail --silent --show-error --max-time 10 "$RAILWAY_HEALTH_URL" > /dev/null; then
-              echo "✓ Railway deploy is healthy (service=${RAILWAY_SERVICE:-nikcli-mobile})"
-              exit 0
-            fi
-            [ "$attempt" -eq 18 ] || sleep 10
-          done
-          echo "✗ Railway deploy completed but failed its health check: $RAILWAY_HEALTH_URL"
-          tail -n 30 tmp/railway.log || true
-          exit 1
+          echo "✓ Railway deploy is healthy (service=${RAILWAY_SERVICE:-nikcli-mobile})"
 
   autofix:
     needs: validate

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_SERVICE: ${{ vars.RAILWAY_SERVICE || 'nikcli-mobile' }}
+          RAILWAY_HEALTH_URL: ${{ vars.RAILWAY_HEALTH_URL || 'https://nikcli-mobile-production.up.railway.app/global/health' }}
         run: |
           if [ -z "${RAILWAY_TOKEN:-}" ]; then
             echo "✗ RAILWAY_TOKEN not configured — skipping deploy"
@@ -109,13 +110,21 @@ jobs:
           fi
           echo "→ Deploying to Railway service: ${RAILWAY_SERVICE:-nikcli-mobile}"
           mkdir -p tmp
-          if ./script/railway-deploy.sh --detach >tmp/railway.log 2>&1; then
-            echo "✓ Railway deploy triggered (service=${RAILWAY_SERVICE:-nikcli-mobile})"
-          else
+          if ! ./script/railway-deploy.sh >tmp/railway.log 2>&1; then
             echo "✗ Railway deploy failed (last 30 lines):"
             tail -n 30 tmp/railway.log || true
             exit 1
           fi
+          for attempt in $(seq 1 18); do
+            if curl --fail --silent --show-error --max-time 10 "$RAILWAY_HEALTH_URL" > /dev/null; then
+              echo "✓ Railway deploy is healthy (service=${RAILWAY_SERVICE:-nikcli-mobile})"
+              exit 0
+            fi
+            [ "$attempt" -eq 18 ] || sleep 10
+          done
+          echo "✗ Railway deploy completed but failed its health check: $RAILWAY_HEALTH_URL"
+          tail -n 30 tmp/railway.log || true
+          exit 1
 
   autofix:
     needs: validate

--- a/Dockerfile.serve
+++ b/Dockerfile.serve
@@ -130,7 +130,7 @@ ENV NIKCLI_SERVER_SSH_HOST=0.0.0.0
 EXPOSE 4096 2222
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -s -o /dev/null "http://127.0.0.1:${PORT:-4096}/" || exit 1
+    CMD curl -fsS -o /dev/null "http://127.0.0.1:${PORT:-4096}/global/health" || exit 1
 
 ENTRYPOINT ["/usr/local/bin/nikcli-railway-entrypoint"]
 

--- a/packages/nikcli/scripts/railway-entrypoint.sh
+++ b/packages/nikcli/scripts/railway-entrypoint.sh
@@ -20,7 +20,10 @@ start_ssh() {
   local ssh_state_dir="/data/ssh"
 
   if [[ -n "${NIKCLI_SSH_AUTHORIZED_KEYS_B64:-}" ]]; then
-    authorized_keys="$(printf '%s' "$NIKCLI_SSH_AUTHORIZED_KEYS_B64" | base64 -d)"
+    if ! authorized_keys="$(printf '%s' "$NIKCLI_SSH_AUTHORIZED_KEYS_B64" | base64 -d)"; then
+      echo "SSH disabled: NIKCLI_SSH_AUTHORIZED_KEYS_B64 is not valid base64." >&2
+      return 1
+    fi
   elif [[ -n "${NIKCLI_SSH_AUTHORIZED_KEYS:-}" ]]; then
     authorized_keys="$NIKCLI_SSH_AUTHORIZED_KEYS"
   fi
@@ -30,15 +33,15 @@ start_ssh() {
     return
   fi
 
-  install -d -m 700 /root/.ssh "$ssh_state_dir"
-  printf '%s\n' "$authorized_keys" > /root/.ssh/authorized_keys
-  chmod 600 /root/.ssh/authorized_keys
+  install -d -m 700 /root/.ssh "$ssh_state_dir" || return 1
+  printf '%s\n' "$authorized_keys" > /root/.ssh/authorized_keys || return 1
+  chmod 600 /root/.ssh/authorized_keys || return 1
 
   if [[ ! -f "$ssh_state_dir/ssh_host_ed25519_key" ]]; then
-    ssh-keygen -q -t ed25519 -N "" -f "$ssh_state_dir/ssh_host_ed25519_key"
+    ssh-keygen -q -t ed25519 -N "" -f "$ssh_state_dir/ssh_host_ed25519_key" || return 1
   fi
-  chmod 600 "$ssh_state_dir/ssh_host_ed25519_key"
-  mkdir -p /run/sshd
+  chmod 600 "$ssh_state_dir/ssh_host_ed25519_key" || return 1
+  mkdir -p /run/sshd || return 1
 
   local sshd_options=(
     -o "Port=$ssh_port"
@@ -52,8 +55,8 @@ start_ssh() {
     -o "AuthorizedKeysFile=/root/.ssh/authorized_keys"
   )
 
-  /usr/sbin/sshd -t "${sshd_options[@]}"
-  /usr/sbin/sshd "${sshd_options[@]}"
+  /usr/sbin/sshd -t "${sshd_options[@]}" || return 1
+  /usr/sbin/sshd "${sshd_options[@]}" || return 1
 
   echo "SSH listening inside Railway on ${ssh_host}:${ssh_port}"
   if [[ -n "${RAILWAY_TCP_PROXY_DOMAIN:-}" && -n "${RAILWAY_TCP_PROXY_PORT:-}" ]]; then
@@ -72,8 +75,9 @@ start_ssh() {
 }
 
 if [[ "${NIKCLI_SERVER_SSH_ENABLED:-true}" == "true" ]]; then
-  start_ssh
+  if ! start_ssh; then
+    echo "Warning: SSH setup failed; continuing with the nikcli mobile server." >&2
+  fi
 fi
 
 exec "$@"
- 

--- a/packages/nikcli/test/release/ci-coherence.test.ts
+++ b/packages/nikcli/test/release/ci-coherence.test.ts
@@ -298,15 +298,13 @@ describe("railway-deploy coherence", () => {
     expect(after).toContain("refs/heads/live-main")
   })
 
-  it("railway-deploy waits for the existing deploy script and health check", async () => {
+  it("railway-deploy waits for Railway to report a healthy deployment", async () => {
     const yml = await read(PIPELINE_YML)
     const rdIdx = yml.indexOf("\n  railway-deploy:")
     const after = yml.slice(rdIdx, rdIdx + 2500)
     expect(after).toContain("./script/railway-deploy.sh >tmp/railway.log")
     expect(after).not.toContain("railway-deploy.sh --detach")
     expect(after).toContain("RAILWAY_TOKEN")
-    expect(after).toContain("RAILWAY_HEALTH_URL")
-    expect(after).toContain("curl --fail --silent --show-error")
   })
 
   it("railway-deploy redirects logs and reports a healthy deployment", async () => {
@@ -327,6 +325,9 @@ describe("railway-deploy coherence", () => {
   it("railway.toml references the serve Dockerfile", async () => {
     const toml = await read("railway.toml")
     expect(toml).toContain("Dockerfile.serve")
+    expect(toml).toContain('healthcheckPath = "/global/health"')
+    expect(toml).toContain('requiredMountPath = "/data"')
+    expect(toml).not.toContain("[[volumes]]")
   })
 })
 

--- a/packages/nikcli/test/release/ci-coherence.test.ts
+++ b/packages/nikcli/test/release/ci-coherence.test.ts
@@ -298,22 +298,25 @@ describe("railway-deploy coherence", () => {
     expect(after).toContain("refs/heads/live-main")
   })
 
-  it("railway-deploy uses the existing deploy script in detach mode", async () => {
+  it("railway-deploy waits for the existing deploy script and health check", async () => {
     const yml = await read(PIPELINE_YML)
     const rdIdx = yml.indexOf("\n  railway-deploy:")
-    const after = yml.slice(rdIdx, rdIdx + 1500)
-    expect(after).toContain("./script/railway-deploy.sh --detach")
+    const after = yml.slice(rdIdx, rdIdx + 2500)
+    expect(after).toContain("./script/railway-deploy.sh >tmp/railway.log")
+    expect(after).not.toContain("railway-deploy.sh --detach")
     expect(after).toContain("RAILWAY_TOKEN")
+    expect(after).toContain("RAILWAY_HEALTH_URL")
+    expect(after).toContain("curl --fail --silent --show-error")
   })
 
-  it("railway-deploy is silent: redirects logs and only emits one-line status", async () => {
+  it("railway-deploy redirects logs and reports a healthy deployment", async () => {
     const yml = await read(PIPELINE_YML)
     const rdIdx = yml.indexOf("\n  railway-deploy:")
-    const after = yml.slice(rdIdx, rdIdx + 1500)
+    const after = yml.slice(rdIdx, rdIdx + 2500)
     // Output is redirected to a log file (not /dev/null) so failures can be
     // tailed for diagnosis, while success stays a single one-line status.
     expect(after).toContain(">tmp/railway.log")
-    expect(after).toContain("✓ Railway deploy triggered")
+    expect(after).toContain("✓ Railway deploy is healthy")
   })
 
   it("railway-deploy.sh script exists and is executable", async () => {

--- a/packages/nikcli/test/release/ci-targeted.test.ts
+++ b/packages/nikcli/test/release/ci-targeted.test.ts
@@ -252,12 +252,11 @@ describe("railway-deploy job specifics", () => {
     expect(yml).toMatch(/RAILWAY_TOKEN\b[\s\S]{0,200}exit 0/)
   })
 
-  it("waits for deployment completion and verifies server health", async () => {
+  it("waits for Railway to report a healthy deployment", async () => {
     const yml = await read(".github/workflows/ci-pipeline.yml")
     expect(yml).toContain("./script/railway-deploy.sh >tmp/railway.log")
     expect(yml).not.toContain("railway-deploy.sh --detach")
-    expect(yml).toContain("RAILWAY_HEALTH_URL")
-    expect(yml).toContain("curl --fail --silent --show-error")
+    expect(yml).toContain("✓ Railway deploy is healthy")
   })
 })
 

--- a/packages/nikcli/test/release/ci-targeted.test.ts
+++ b/packages/nikcli/test/release/ci-targeted.test.ts
@@ -252,9 +252,12 @@ describe("railway-deploy job specifics", () => {
     expect(yml).toMatch(/RAILWAY_TOKEN\b[\s\S]{0,200}exit 0/)
   })
 
-  it("uses --detach so the workflow doesn't block on deploy completion", async () => {
+  it("waits for deployment completion and verifies server health", async () => {
     const yml = await read(".github/workflows/ci-pipeline.yml")
-    expect(yml).toContain("railway-deploy.sh --detach")
+    expect(yml).toContain("./script/railway-deploy.sh >tmp/railway.log")
+    expect(yml).not.toContain("railway-deploy.sh --detach")
+    expect(yml).toContain("RAILWAY_HEALTH_URL")
+    expect(yml).toContain("curl --fail --silent --show-error")
   })
 })
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,9 @@
 [build]
 dockerfilePath = "Dockerfile.serve"
 
+[deploy]
+healthcheckPath = "/global/health"
+healthcheckTimeout = 300
+
 [[volumes]]
 mountPath = "/data"

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,4 @@ dockerfilePath = "Dockerfile.serve"
 [deploy]
 healthcheckPath = "/global/health"
 healthcheckTimeout = 300
-
-[[volumes]]
-mountPath = "/data"
+requiredMountPath = "/data"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Issue for this PR

The public mobile endpoint can remain on a 502 while CI reports a successful detached Railway deploy.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Waits for Railway deployment completion and its native `/global/health` check before CI reports success. Railway and Docker use the same unauthenticated API health endpoint, the deployment requires the existing `/data` volume mount using Railway's supported schema, and optional SSH setup failures no longer terminate the mobile server container.

### How did you verify your code works?

Shell syntax, workflow YAML parsing, Railway schema review, deployment assertions, and diff checks passed. Focused Bun tests could not run locally because Bun is not installed in the cloud environment; repository CI runs them.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49b6-e73e-77f9-b999-b295bd9061b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49b6-e73e-77f9-b999-b295bd9061b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

