### PR TITLE
fix(ci): add missing workspace packages to Docker and Railway builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,16 @@ COPY packages/remote/package.json packages/remote/
 COPY packages/plugin/package.json packages/plugin/
 COPY packages/companion/package.json packages/companion/
 COPY packages/slack/package.json packages/slack/
+COPY packages/llm/package.json packages/llm/
+COPY packages/http-recorder/package.json packages/http-recorder/
+COPY packages/httpapi-codegen/package.json packages/httpapi-codegen/
+COPY packages/simulation/package.json packages/simulation/
 COPY packages/tui-image/package.json packages/tui-image/
 COPY github/package.json github/
+
+# Stub webrenderer (native Rust build not required for the nikcli binary)
+RUN mkdir -p packages/webrenderer && \
+    printf '{"name":"@opentui/webrenderer","version":"0.0.0","private":true}\n' > packages/webrenderer/package.json
 
 # Install dependencies (resolves workspace:*)
 RUN bun install
@@ -34,6 +42,10 @@ COPY packages/remote packages/remote
 COPY packages/plugin packages/plugin
 COPY packages/companion packages/companion
 COPY packages/slack packages/slack
+COPY packages/llm packages/llm
+COPY packages/http-recorder packages/http-recorder
+COPY packages/httpapi-codegen packages/httpapi-codegen
+COPY packages/simulation packages/simulation
 COPY packages/tui-image packages/tui-image
 COPY github github
 

--- a/Dockerfile.serve
+++ b/Dockerfile.serve
@@ -32,6 +32,8 @@ COPY packages/companion/package.json /app/packages/companion/
 COPY packages/slack/package.json /app/packages/slack/
 COPY packages/llm/package.json /app/packages/llm/
 COPY packages/http-recorder/package.json /app/packages/http-recorder/
+COPY packages/httpapi-codegen/package.json /app/packages/httpapi-codegen/
+COPY packages/simulation/package.json /app/packages/simulation/
 COPY packages/tui-image/package.json /app/packages/tui-image/
 COPY github/package.json /app/github/
 
@@ -82,12 +84,14 @@ COPY packages/companion /app/packages/companion
 COPY packages/slack /app/packages/slack
 COPY packages/llm /app/packages/llm
 COPY packages/http-recorder /app/packages/http-recorder
+COPY packages/httpapi-codegen /app/packages/httpapi-codegen
+COPY packages/simulation /app/packages/simulation
 COPY packages/tui-image /app/packages/tui-image
 COPY github /app/github
 
 ENV NIKCLI_CHANNEL=latest
 ENV NIKCLI_VERSION=1.5.0
-RUN cd /app && bun install --os="*" --cpu="*" @opentui/solid@0.1.95 @effect/platform-bun@4.0.0-beta.65
+RUN cd /app && bun install --os="*" --cpu="*" @opentui/solid@0.1.95 @effect/platform-bun@4.0.0-beta.83
 RUN cd /app/packages/nikcli && bun run script/build.ts --single --skip-install
 
 FROM base AS runtime

--- a/packages/slack/Dockerfile
+++ b/packages/slack/Dockerfile
@@ -23,6 +23,8 @@ COPY packages/llm/package.json packages/llm/
 COPY packages/tui-image/package.json packages/tui-image/
 COPY packages/webrenderer/package.json packages/webrenderer/
 COPY packages/http-recorder/package.json packages/http-recorder/
+COPY packages/httpapi-codegen/package.json packages/httpapi-codegen/
+COPY packages/simulation/package.json packages/simulation/
 # Explicit workspace member referenced by root package.json
 COPY github/package.json github/
 
@@ -41,6 +43,8 @@ COPY packages/llm packages/llm
 COPY packages/tui-image packages/tui-image
 COPY packages/webrenderer packages/webrenderer
 COPY packages/http-recorder packages/http-recorder
+COPY packages/httpapi-codegen packages/httpapi-codegen
+COPY packages/simulation packages/simulation
 
 RUN mkdir -p /app/repos
 

--- a/script/railway-deploy.sh
+++ b/script/railway-deploy.sh
@@ -34,6 +34,8 @@ mkdir -p \
   "$CTX/packages/slack" \
   "$CTX/packages/llm" \
   "$CTX/packages/http-recorder" \
+  "$CTX/packages/httpapi-codegen" \
+  "$CTX/packages/simulation" \
   "$CTX/packages/tui-image" \
   "$CTX/github"
 
@@ -57,6 +59,8 @@ cp "$ROOT/packages/companion/package.json" "$CTX/packages/companion/package.json
 cp "$ROOT/packages/slack/package.json" "$CTX/packages/slack/package.json"
 cp "$ROOT/packages/llm/package.json" "$CTX/packages/llm/package.json"
 cp "$ROOT/packages/http-recorder/package.json" "$CTX/packages/http-recorder/package.json"
+cp "$ROOT/packages/httpapi-codegen/package.json" "$CTX/packages/httpapi-codegen/package.json"
+cp "$ROOT/packages/simulation/package.json" "$CTX/packages/simulation/package.json"
 cp "$ROOT/packages/tui-image/package.json" "$CTX/packages/tui-image/package.json"
 cp "$ROOT/github/package.json" "$CTX/github/package.json"
 
@@ -95,6 +99,8 @@ rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/companion/"     "$CTX/packages/companio
 rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/slack/"         "$CTX/packages/slack/"
 rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/llm/"           "$CTX/packages/llm/"
 rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/http-recorder/" "$CTX/packages/http-recorder/"
+rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/httpapi-codegen/" "$CTX/packages/httpapi-codegen/"
+rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/simulation/"     "$CTX/packages/simulation/"
 rsync "${RSYNC_OPTS[@]}" "$ROOT/packages/tui-image/"     "$CTX/packages/tui-image/"
 rsync "${RSYNC_OPTS[@]}" "$ROOT/github/"                 "$CTX/github/"
 
@@ -125,6 +131,10 @@ rm -rf \
   "$CTX/packages/llm/.turbo" \
   "$CTX/packages/http-recorder/.cache" \
   "$CTX/packages/http-recorder/.turbo" \
+  "$CTX/packages/httpapi-codegen/.cache" \
+  "$CTX/packages/httpapi-codegen/.turbo" \
+  "$CTX/packages/simulation/.cache" \
+  "$CTX/packages/simulation/.turbo" \
   "$CTX/packages/tui-image/.cache" \
   "$CTX/packages/tui-image/.turbo" \
   "$CTX/github/.cache" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After adding `@nikcli-ai/httpapi-codegen` and `@nikcli-ai/simulation` as nikcli workspace dependencies, Docker builds started failing during `bun install` with unresolved workspace errors:

```
error: Workspace dependency "@nikcli-ai/httpapi-codegen" not found
error: Workspace dependency "@nikcli-ai/simulation" not found
```

This affected:
- `Dockerfile.serve` (Railway mobile serve image)
- Root `Dockerfile` (GHCR publish image)
- `packages/slack/Dockerfile` (Slack bot container)
- `script/railway-deploy.sh` (minimal Railway deploy context)

## Solution

Added the missing workspace packages to all Docker build contexts and the Railway deploy script:

- **`Dockerfile.serve`**: copy `httpapi-codegen` and `simulation` manifests + sources; align `@effect/platform-bun` to `4.0.0-beta.83`
- **`Dockerfile`**: add `llm`, `http-recorder`, `httpapi-codegen`, `simulation`; stub `@opentui/webrenderer` for install resolution
- **`script/railway-deploy.sh`**: sync the same packages into the minimal Railway build context
- **`packages/slack/Dockerfile`**: add `httpapi-codegen` and `simulation`

## Verification

- Simulated `bun install` with each Docker manifest set — all resolve successfully
- `bun test test/release/ci-coherence.test.ts test/release/ci-targeted.test.ts` — 107 pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5e90-dd65-78cf-8ad6-152a55dc412f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5e90-dd65-78cf-8ad6-152a55dc412f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

